### PR TITLE
Fix/dtynn/enable proofs features and fix docs

### DIFF
--- a/.github/workflows/compile-go-on-pr.yaml
+++ b/.github/workflows/compile-go-on-pr.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: dependencies
-        run: sudo apt update & sudo apt upgrade & sudo apt install --reinstall mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget -y
+        run: sudo apt update && sudo apt install --reinstall ocl-icd-opencl-dev libhwloc-dev -y
 
       - name: setup go
         uses: actions/setup-go@v2

--- a/.github/workflows/compile-on-push.yaml
+++ b/.github/workflows/compile-on-push.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: dependencies
-        run: sudo apt update & sudo apt upgrade & sudo apt install --reinstall mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget -y
+        run: sudo apt update && sudo apt install --reinstall ocl-icd-opencl-dev libhwloc-dev -y
 
       - name: setup go
         uses: actions/setup-go@v2

--- a/.github/workflows/compile-rust-on-pr.yaml
+++ b/.github/workflows/compile-rust-on-pr.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: dependencies
-        run: sudo apt update & sudo apt upgrade & sudo apt install --reinstall mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget -y
+        run: sudo apt update && sudo apt install --reinstall ocl-icd-opencl-dev libhwloc-dev -y
 
       - name: setup rust
         uses: actions-rs/toolchain@v1

--- a/docs/zh/03.venus-worker的配置解析.md
+++ b/docs/zh/03.venus-worker的配置解析.md
@@ -445,36 +445,36 @@ location = "/mnt/remote/10.0.0.14/store"
 [[processors.pc1]]
 numa_preferred = 0
 cgroup.cpuset = "0-3"
-env = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 [[processors.pc1]]
 numa_preferred = 0
 cgroup.cpuset = "4-7"
-env = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 [[processors.pc1]]
 numa_preferred = 1
 cgroup.cpuset = "12-15"
-env = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 [[processors.pc1]]
 numa_preferred = 1
 cgroup.cpuset = "16-19"
-env = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 
 [[processors.pc2]]
 cgroup.cpuset = "8-11,24-27"
-env = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "0" }
+envs = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "0" }
 
 [[processors.pc2]]
 cgroup.cpuset = "20-23,36-39"
-env = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "1" }
+envs = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "1" }
 
 
 [[processors.c2]]
 cgroup.cpuset = "28-35"
-env = { CUDA_VISIBLE_DEVICES = "2,3" }
+envs = { CUDA_VISIBLE_DEVICES = "2,3" }
 
 
 [[processors.tree_d]]
@@ -498,7 +498,7 @@ cgroup.cpuset = "40-45"
 [[processors.c2]]
 bin = /usr/local/bin/venus-worker-c2-optimized
 cgroup.cpuset = "40-47"
-env = { CUDA_VISIBLE_DEVICES = "2,3" }
+envs = { CUDA_VISIBLE_DEVICES = "2,3" }
 ```
 
 
@@ -509,7 +509,7 @@ env = { CUDA_VISIBLE_DEVICES = "2,3" }
 [[processors.c2]]
 bin = /usr/local/bin/venus-worker-c2-outsource
 args = ["--url", "/ip4/apis.filecoin.io/tcp/10086/https", "--timeout", "10s"]
-env = { LICENCE_PATH = "/var/tmp/c2.licence.dev" }
+envs = { LICENCE_PATH = "/var/tmp/c2.licence.dev" }
 ```
 
 
@@ -519,7 +519,7 @@ env = { LICENCE_PATH = "/var/tmp/c2.licence.dev" }
 ```
 [[processors.pc2]]
 cgroup.cpuset = "8-11,24-27"
-env = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "0" }
+envs = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "0" }
 
 [[processors.pc2]]
 cgroup.cpuset = "20-23,36-45"
@@ -571,36 +571,36 @@ location = "{path to remote store}"
 [[processors.pc1]]
 numa_preferred = 0
 cgroup.cpuset = "0-3"
-env = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 [[processors.pc1]]
 numa_preferred = 0
 cgroup.cpuset = "4-7"
-env = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 [[processors.pc1]]
 numa_preferred = 1
 cgroup.cpuset = "12-15"
-env = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 [[processors.pc1]]
 numa_preferred = 1
 cgroup.cpuset = "16-19"
-env = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 
 [[processors.pc2]]
 cgroup.cpuset = "8-11,24-27"
-env = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "0" }
+envs = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "0" }
 
 [[processors.pc2]]
 cgroup.cpuset = "20-23,36-39"
-env = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "1" }
+envs = { FIL_PROOFS_USE_GPU_COLUMN_BUILDER = "1", FIL_PROOFS_USE_GPU_TREE_BUILDER = "1", CUDA_VISIBLE_DEVICES = "1" }
 
 
 [[processors.c2]]
 cgroup.cpuset = "28-35"
-env = { CUDA_VISIBLE_DEVICES = "2,3" }
+envs = { CUDA_VISIBLE_DEVICES = "2,3" }
 
 
 [[processors.tree_d]]

--- a/venus-worker/Cargo.lock
+++ b/venus-worker/Cargo.lock
@@ -286,7 +286,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -298,6 +298,12 @@ dependencies = [
  "rustc-hash",
  "shlex",
 ]
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 
 [[package]]
 name = "bitflags"
@@ -618,7 +624,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -772,7 +778,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -818,6 +824,24 @@ checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-driver-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
+dependencies = [
+ "cuda-config",
 ]
 
 [[package]]
@@ -934,6 +958,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2b2decb0484e15560df3210cf0d78654bb0864b2c138977c07e377a1bae0e2"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1044,18 @@ dependencies = [
  "bitvec 0.22.3",
  "rand_core 0.6.2",
  "subtle",
+]
+
+[[package]]
+name = "fil-rustacuda"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6313e2871ba9705f4151bb60d96b6f43e7444ed82918ba5fb99fbd448e82c34d"
+dependencies = [
+ "bitflags 1.2.1",
+ "cuda-driver-sys",
+ "rustacuda_core",
+ "rustacuda_derive",
 ]
 
 [[package]]
@@ -1651,6 +1698,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hwloc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "657dd2f25a0ff8c4f19c4f7ab42d3ffad0a7f282b6e73adafa4b4448d95f60cf"
+dependencies = [
+ "bitflags 0.4.0",
+ "errno",
+ "libc",
+ "num",
+ "pkg-config",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,7 +2006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.2.1",
  "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
@@ -2245,7 +2305,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -2272,6 +2332,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+dependencies = [
+ "num-bigint 0.1.44",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.4.6",
+ "rustc-serialize",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
+dependencies = [
+ "num-traits",
+ "rustc-serialize",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,6 +2408,29 @@ checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
+dependencies = [
+ "num-bigint 0.1.44",
+ "num-integer",
+ "num-traits",
+ "rustc-serialize",
 ]
 
 [[package]]
@@ -2367,7 +2486,7 @@ version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -2774,7 +2893,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
 ]
 
 [[package]]
@@ -2873,6 +2992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1785ab2a8accec77189e23fead221f2543cebf7ccf569788511cdac9f5fad168"
 dependencies = [
  "dirs",
+ "fil-rustacuda",
  "hex",
  "lazy_static",
  "log",
@@ -2882,10 +3002,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustacuda_core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3858b08976dc2f860c5efbbb48cdcb0d4fafca92a6ac0898465af16c0dbe848"
+
+[[package]]
+name = "rustacuda_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "ryu"
@@ -2915,7 +3058,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3220,6 +3363,7 @@ dependencies = [
  "fr32",
  "generic-array 0.14.4",
  "hex",
+ "hwloc",
  "lazy_static",
  "libc",
  "log",

--- a/venus-worker/Cargo.toml
+++ b/venus-worker/Cargo.toml
@@ -8,9 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-filecoin-proofs-api = "11.0.0"
 storage-proofs-core = "11.0.2"
-filecoin-proofs = "11.0.2"
 memmap = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.56"
@@ -39,6 +37,16 @@ flexi_logger = "0.18"
 ansi_term = "0.12.1"
 multiaddr = "0.14.0"
 
+[dependencies.filecoin-proofs-api]
+version = "11"
+default-features = false
+features = ["opencl", "multicore-sdr"]
+
+[dependencies.filecoin-proofs]
+version = "11.0.2"
+default-features = false
+features = ["opencl", "multicore-sdr"]
+
 [dependencies.reqwest]
 version = "0.11"
 features = ["blocking"]
@@ -61,3 +69,4 @@ features = ["tls", "http"]
 [features]
 default = ["numa"]
 numa = []
+cuda = ["filecoin-proofs/cuda", "filecoin-proofs-api/cuda"]

--- a/venus-worker/assets/venus-worker.mock.toml
+++ b/venus-worker/assets/venus-worker.mock.toml
@@ -61,6 +61,7 @@ envs = { RUST_LOG = "info" }
 [[processors.pc1]]
 numa_preferred = 0
 cgroup.cpuset = "6-7"
+envs = { FIL_PROOFS_USE_MULTICORE_SDR = "1" }
 
 [[processors.pc1]]
 numa_preferred = 1


### PR DESCRIPTION
- 修复文档中关于 `envs` 字段的示例
- 默认启用 `opencl` 和 `multicore-sdr`，并支持启用 `cuda`