### PR TITLE
fix: deal ids should only collect non-zero ones

### DIFF
--- a/venus-sector-manager/api/types_sector_state.go
+++ b/venus-sector-manager/api/types_sector_state.go
@@ -25,9 +25,11 @@ type SectorState struct {
 }
 
 func (s SectorState) DealIDs() []abi.DealID {
-	res := make([]abi.DealID, len(s.Deals))
+	res := make([]abi.DealID, 0, len(s.Deals))
 	for i := range s.Deals {
-		res[i] = s.Deals[i].ID
+		if id := s.Deals[i].ID; id != 0 {
+			res = append(res, id)
+		}
 	}
 	return res
 }
@@ -35,6 +37,6 @@ func (s SectorState) DealIDs() []abi.DealID {
 type SectorWorkerState string
 
 const (
-	WorkerOnline SectorWorkerState = "online"
+	WorkerOnline  SectorWorkerState = "online"
 	WorkerOffline SectorWorkerState = "offline"
 )


### PR DESCRIPTION
- 只应当收集真实（非零）的订单ID