### PR TITLE
Feat/dtynn/reduce logs for hyper

### DIFF
--- a/venus-worker/Cargo.lock
+++ b/venus-worker/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi 0.3.9",
 ]
 
@@ -1074,7 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b13cb584f73da360e279d33d8751931541a922602b7a09ce043548aebf08d10"
 dependencies = [
  "atty",
- "flexi_logger 0.14.8",
+ "flexi_logger",
  "log",
 ]
 
@@ -1191,22 +1191,6 @@ dependencies = [
  "glob",
  "log",
  "regex",
- "yansi",
-]
-
-[[package]]
-name = "flexi_logger"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba2265890613939b533fa11c3728651531419ac549ccf527896201581f23991"
-dependencies = [
- "atty",
- "chrono",
- "glob",
- "lazy_static",
- "log",
- "regex",
- "thiserror",
  "yansi",
 ]
 
@@ -2014,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.96"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "libloading"
@@ -2071,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -2449,6 +2433,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
  "libc",
 ]
 
@@ -3553,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -3578,6 +3571,17 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -3700,11 +3704,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -3719,35 +3724,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.18"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time 0.3.9",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -3849,6 +3841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "value-bag"
 version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,7 +3872,6 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 name = "venus-worker"
 version = "0.1.0"
 dependencies = [
- "ansi_term 0.12.1",
  "anyhow",
  "base64",
  "base64-serde",
@@ -3888,7 +3885,6 @@ dependencies = [
  "fil_types",
  "filecoin-proofs",
  "filecoin-proofs-api",
- "flexi_logger 0.18.0",
  "forest_address",
  "forest_cid",
  "forest_json_utils",

--- a/venus-worker/Cargo.toml
+++ b/venus-worker/Cargo.toml
@@ -22,7 +22,7 @@ fil_clock = "0.1"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8.5"
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "local-time"] }
 crossterm = "0.20"
 jsonrpc-core = "18"
 jsonrpc-derive = "18"
@@ -33,8 +33,6 @@ clap = "2.33"
 byte-unit = "4"
 cgroups-rs = "0.2"
 signal-hook = "0.3"
-flexi_logger = "0.18"
-ansi_term = "0.12.1"
 multiaddr = "0.14.0"
 
 [dependencies.filecoin-proofs-api]

--- a/venus-worker/Cargo.toml
+++ b/venus-worker/Cargo.toml
@@ -22,7 +22,7 @@ fil_clock = "0.1"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8.5"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "local-time"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 crossterm = "0.20"
 jsonrpc-core = "18"
 jsonrpc-derive = "18"

--- a/venus-worker/src/logging/mod.rs
+++ b/venus-worker/src/logging/mod.rs
@@ -38,7 +38,7 @@ pub fn init() -> Result<()> {
         .with_ansi(std::io::stderr().is_tty())
         .with_target(true)
         .with_thread_ids(true)
-        .with_timer(time::LocalTime::rfc_3339())
+        .with_timer(time::UtcTime::rfc_3339())
         .with_filter(env_filter.or(worker_env_filter));
 
     registry().with(fmt_layer).init();

--- a/venus-worker/src/logging/mod.rs
+++ b/venus-worker/src/logging/mod.rs
@@ -1,15 +1,13 @@
 //! provides logging helpers
 
-use std::io::{Error, Write};
-
-use ansi_term::{Colour, Style};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossterm::tty::IsTty;
-use flexi_logger::{
-    DeferredNow, Level, LevelFilter, LogSpecBuilder, LogSpecification, Logger, Record,
+use tracing_subscriber::{
+    filter::{self, FilterExt},
+    fmt::{layer, time},
+    prelude::*,
+    registry,
 };
-use tracing::subscriber::set_global_default;
-use tracing_subscriber::{fmt::time, EnvFilter, FmtSubscriber};
 
 pub use tracing::{
     debug, debug_span, error, error_span, field::debug as debug_field,
@@ -18,83 +16,32 @@ pub use tracing::{
 
 /// initiate the global tracing subscriber
 pub fn init() -> Result<()> {
-    let builder = FmtSubscriber::builder()
+    let env_filter = filter::EnvFilter::builder()
+        .with_default_directive(filter::LevelFilter::DEBUG.into())
+        .from_env()
+        .context("invalid env filter")?
+        .add_directive("want=warn".parse()?)
+        .add_directive("jsonrpc_client_transports=warn".parse()?)
+        .add_directive("jsonrpc_core=warn".parse()?)
+        .add_directive("hyper=warn".parse()?)
+        .add_directive("mio=warn".parse()?)
+        .add_directive("reqwest=warn".parse()?);
+
+    let worker_env_filter = filter::EnvFilter::builder()
+        .with_default_directive(filter::LevelFilter::OFF.into())
+        .with_env_var("VENUS_WORKER_LOG")
+        .from_env()
+        .context("invalid venus worker log filter")?;
+
+    let fmt_layer = layer()
         .with_writer(std::io::stderr)
         .with_ansi(std::io::stderr().is_tty())
-        .with_env_filter(EnvFilter::from_default_env())
         .with_target(true)
         .with_thread_ids(true)
-        .with_timer(time::ChronoLocal::rfc3339());
+        .with_timer(time::LocalTime::rfc_3339())
+        .with_filter(env_filter.or(worker_env_filter));
 
-    set_global_default(builder.finish())?;
-
-    init_flexi_logger()
-}
-
-fn init_flexi_logger() -> Result<()> {
-    let mut builder = LogSpecBuilder::new();
-    builder.default(LevelFilter::Info);
-    builder.module("jsonrpc_client_transports", LevelFilter::Warn);
-    builder.module("jsonrpc_core", LevelFilter::Warn);
-    builder.module("jsonrpc_ws_server", LevelFilter::Warn);
-    builder.module("parity_ws", LevelFilter::Warn);
-
-    let from_env = LogSpecification::env()?;
-    builder.insert_modules_from(from_env);
-
-    let logger =
-        Logger::with(builder.finalize())
-            .log_to_stderr()
-            .format(if std::io::stderr().is_tty() {
-                flexi_colored_format
-            } else {
-                flexi_no_color_format
-            });
-
-    logger.start()?;
+    registry().with(fmt_layer).init();
 
     Ok(())
-}
-
-fn flexi_no_color_format(
-    w: &mut dyn Write,
-    now: &mut DeferredNow,
-    record: &Record<'_>,
-) -> Result<(), Error> {
-    write!(
-        w,
-        "{} {} {:?} {}: {}",
-        now.now().to_rfc3339(),
-        record.level(),
-        std::thread::current().id(),
-        record.module_path().unwrap_or("<unnamed>"),
-        &record.args(),
-    )
-}
-
-fn flexi_colored_format(
-    w: &mut dyn Write,
-    now: &mut DeferredNow,
-    record: &Record<'_>,
-) -> Result<(), Error> {
-    let level = record.level();
-    write!(
-        w,
-        "{} {} {:?} {}: {}",
-        Style::new().dimmed().paint(now.now().to_rfc3339()),
-        style_for_level(level).paint(level.as_str()),
-        std::thread::current().id(),
-        record.module_path().unwrap_or("<unnamed>"),
-        &record.args(),
-    )
-}
-
-fn style_for_level(l: Level) -> Style {
-    match l {
-        Level::Trace => Style::new().fg(Colour::Purple),
-        Level::Debug => Style::new().fg(Colour::Blue),
-        Level::Info => Style::new().fg(Colour::Green),
-        Level::Warn => Style::new().fg(Colour::Yellow),
-        Level::Error => Style::new().fg(Colour::Red),
-    }
 }


### PR DESCRIPTION
- 将 `tracing-subscriber` 升级到 0.3
- 调整 logger 的初始化方法以适应版本升级
- 移除 `flexi_logger` 及关联的依赖
- 将一些不太关注的库的默认日志级别调高，并支持通过环境变量 `VENUS_WORKER_LOG` 进行控制