### PR TITLE
fix(vsmgr): ignore incompleted upgrade sectors

### DIFF
--- a/venus-sector-manager/modules/impl/sectors/snapup_commit.go
+++ b/venus-sector-manager/modules/impl/sectors/snapup_commit.go
@@ -142,6 +142,11 @@ func (sc *SnapUpCommitter) commitSector(state api.SectorState) {
 		return
 	}
 
+	if state.UpgradedInfo == nil {
+		slog.Debug("not completed yet")
+		return
+	}
+
 	if err := sc.indexer.Upgrade().Update(sc.ctx, state.ID, state.UpgradedInfo.AccessInstance); err != nil {
 		slog.Errorf("failed to update upgrade indexer: %s", err)
 		return


### PR DESCRIPTION
- 修复：启动循环中忽略尚未完成的snapup 扇区