### PR TITLE
Feat/dtynn/abort on submit or poll status

### DIFF
--- a/venus-sector-manager/core/types.go
+++ b/venus-sector-manager/core/types.go
@@ -76,6 +76,7 @@ const (
 	OnChainStateFailed
 	// worker should enter perm err
 	OnChainStatePermFailed
+	OnChainStateShouldAbort
 )
 
 type PreCommitOnChainInfo struct {

--- a/venus-worker/src/rpc/sealer/mod.rs
+++ b/venus-worker/src/rpc/sealer/mod.rs
@@ -201,6 +201,9 @@ pub enum OnChainState {
 
     /// permanent failed
     PermFailed = 6,
+
+    /// the sector is not going to get on-chain
+    ShouldAbort = 7,
 }
 
 /// required infos for pre commint

--- a/venus-worker/src/sealing/worker/task/planner/sealer.rs
+++ b/venus-worker/src/sealing/worker/task/planner/sealer.rs
@@ -453,6 +453,8 @@ impl<'c, 't> Sealer<'c, 't> {
 
                 OnChainState::PermFailed => return Err(anyhow!("pre commit on-chain info permanent failed: {:?}", state.desc).perm()),
 
+                OnChainState::ShouldAbort => return Err(anyhow!("pre commit info will not get on-chain: {:?}", state.desc).abort()),
+
                 OnChainState::Pending | OnChainState::Packed => {}
             }
 
@@ -674,6 +676,8 @@ impl<'c, 't> Sealer<'c, 't> {
                     }
 
                     OnChainState::PermFailed => return Err(anyhow!("proof on-chain info permanent failed: {:?}", state.desc).perm()),
+
+                    OnChainState::ShouldAbort => return Err(anyhow!("sector will not get on-chain: {:?}", state.desc).abort()),
 
                     OnChainState::Pending | OnChainState::Packed => {}
                 }

--- a/venus-worker/src/sealing/worker/task/planner/sealer.rs
+++ b/venus-worker/src/sealing/worker/task/planner/sealer.rs
@@ -424,7 +424,7 @@ impl<'c, 't> Sealer<'c, 't> {
 
             SubmitResult::MismatchedSubmission => Err(anyhow!("{:?}: {:?}", res.res, res.desc).perm()),
 
-            SubmitResult::Rejected => Err(anyhow!("{:?}: {:?}", res.res, res.desc).perm()),
+            SubmitResult::Rejected => Err(anyhow!("{:?}: {:?}", res.res, res.desc).abort()),
 
             SubmitResult::FilesMissed => Err(anyhow!("FilesMissed should not happen for pc2 submission: {:?}", res.desc).perm()),
         }
@@ -640,7 +640,7 @@ impl<'c, 't> Sealer<'c, 't> {
 
             SubmitResult::MismatchedSubmission => Err(anyhow!("{:?}: {:?}", res.res, res.desc).perm()),
 
-            SubmitResult::Rejected => Err(anyhow!("{:?}: {:?}", res.res, res.desc).perm()),
+            SubmitResult::Rejected => Err(anyhow!("{:?}: {:?}", res.res, res.desc).abort()),
 
             SubmitResult::FilesMissed => Err(anyhow!("FilesMissed is not handled currently: {:?}", res.desc).perm()),
         }


### PR DESCRIPTION
通过以下两种手段
- 明确 SubmitResult::Rejected 的语义
- 增加 OnChainState::ShouldAbort 的定义
使 worker 不会阻塞在明显无法修复的状态上，转而终止当前任务

resolve #143 
resolve #88 