### PR TITLE
Feat/dtynn/configurable snapup policy

### DIFF
--- a/docs/zh/04.venus-sector-manager的配置解析.md
+++ b/docs/zh/04.venus-sector-manager的配置解析.md
@@ -40,6 +40,7 @@
 [Miners.SnapUp]
 #Enabled = false
 #Sender = "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"
+#SendFund = true
 #GasOverEstimation = 1.2
 #MaxFeeCap = "5 nanoFIL"
 #MessageConfidential = 15
@@ -52,6 +53,7 @@
 [Miners.Commitment]
 #Confidence = 10
 [Miners.Commitment.Pre]
+#SendFund = true
 #Sender = "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"
 #GasOverEstimation = 1.2
 #MaxFeeCap = "5 nanoFIL"
@@ -63,6 +65,7 @@
 #GasOverEstimation = 1.2
 #MaxFeeCap = "5 nanoFIL"
 [Miners.Commitment.Prove]
+#SendFund = true
 #Sender = "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"
 #GasOverEstimation = 1.2
 #MaxFeeCap = "5 nanoFIL"
@@ -235,6 +238,10 @@ InitNumber = 0
 # 发送地址，在启用的情况下为必填项，地址类型
 #Sender = "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"
 
+# 提交上链消息时是否从 Sender 发送必要的资金，选填项，布尔类型
+# 默认值为 true
+#SendFund = true
+
 # 单条提交消息的 Gas 估算倍数，选填项，浮点数类型
 # 默认值为1.2
 #GasOverEstimation = 1.2
@@ -294,6 +301,10 @@ InitNumber = 0
 
 ```
 [Miners.Commitment.Pre]
+# 提交上链消息时是否从 Sender 发送必要的资金，选填项，布尔类型
+# 默认值为 true
+#SendFund = true
+
 # 发送地址，必填项，地址类型
 Sender = "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"
 

--- a/docs/zh/04.venus-sector-manager的配置解析.md
+++ b/docs/zh/04.venus-sector-manager的配置解析.md
@@ -44,6 +44,11 @@
 #MaxFeeCap = "5 nanoFIL"
 #MessageConfidential = 15
 #ReleaseCondidential = 30
+[Miners.SnapUp.Retry]
+#MaxAttempts = 10
+#PollInterval = "3m0s"
+#APIFailureWait = "3m0s"
+#LocalFailureWait = "3m0s"
 [Miners.Commitment]
 #Confidence = 10
 [Miners.Commitment.Pre]
@@ -245,6 +250,25 @@ InitNumber = 0
 # 释放旧数据存储空间的确信高度，选填项，数字类型
 # 默认值为 30
 #ReleaseCondidential = 30
+
+# SnapUp 提交重试策略
+[Miners.SnapUp.Retry]
+
+# 最大重试次数，选填项，数字类型
+# 默认为 NULL，表示不做限制
+#MaxAttempts = 10
+
+# 轮询状态的间隔，选填项，事件类型
+# 默认值为 3min
+#PollInterval = "3m0s"
+
+# API 接口异常的重试间隔，选填项，事件类型
+# 默认值为 3min
+#APIFailureWait = "3m0s"
+
+# 本地异常的重试间隔，如本地数据库异常、本地存储异常等，选填项，事件类型
+# 默认值为 3min
+#LocalFailureWait = "3m0s"
 ```
 
 ### [Miners.Commitment]

--- a/venus-sector-manager/modules/config.go
+++ b/venus-sector-manager/modules/config.go
@@ -166,8 +166,9 @@ func defaultMinerSnapUpRetryConfig(example bool) MinerSnapUpRetryConfig {
 }
 
 type MinerSnapUpConfig struct {
-	Enabled bool
-	Sender  MustAddress
+	Enabled  bool
+	Sender   MustAddress
+	SendFund bool
 	FeeConfig
 	MessageConfidential abi.ChainEpoch
 	ReleaseCondidential abi.ChainEpoch
@@ -177,6 +178,7 @@ type MinerSnapUpConfig struct {
 func defaultMinerSnapUpConfig(example bool) MinerSnapUpConfig {
 	cfg := MinerSnapUpConfig{
 		Enabled:             false,
+		SendFund:            true,
 		FeeConfig:           defaultFeeConfig(),
 		MessageConfidential: 15,
 		ReleaseCondidential: 30,

--- a/venus-sector-manager/modules/config.go
+++ b/venus-sector-manager/modules/config.go
@@ -142,12 +142,36 @@ func defaultMinerSectorConfig(example bool) MinerSectorConfig {
 	return cfg
 }
 
+type MinerSnapUpRetryConfig struct {
+	MaxAttempts      *int
+	PollInterval     Duration
+	APIFailureWait   Duration
+	LocalFailureWait Duration
+}
+
+func defaultMinerSnapUpRetryConfig(example bool) MinerSnapUpRetryConfig {
+	cfg := MinerSnapUpRetryConfig{
+		MaxAttempts:      nil,
+		PollInterval:     Duration(3 * time.Minute),
+		APIFailureWait:   Duration(3 * time.Minute),
+		LocalFailureWait: Duration(3 * time.Minute),
+	}
+
+	if example {
+		maxAttempts := 10
+		cfg.MaxAttempts = &maxAttempts
+	}
+
+	return cfg
+}
+
 type MinerSnapUpConfig struct {
 	Enabled bool
 	Sender  MustAddress
 	FeeConfig
 	MessageConfidential abi.ChainEpoch
 	ReleaseCondidential abi.ChainEpoch
+	Retry               MinerSnapUpRetryConfig
 }
 
 func defaultMinerSnapUpConfig(example bool) MinerSnapUpConfig {
@@ -156,6 +180,7 @@ func defaultMinerSnapUpConfig(example bool) MinerSnapUpConfig {
 		FeeConfig:           defaultFeeConfig(),
 		MessageConfidential: 15,
 		ReleaseCondidential: 30,
+		Retry:               defaultMinerSnapUpRetryConfig(example),
 	}
 
 	if example {

--- a/venus-sector-manager/modules/config.go
+++ b/venus-sector-manager/modules/config.go
@@ -209,13 +209,15 @@ func defaultMinerCommitmentConfig(example bool) MinerCommitmentConfig {
 }
 
 type MinerCommitmentPolicyConfig struct {
-	Sender MustAddress
+	Sender   MustAddress
+	SendFund bool
 	FeeConfig
 	Batch MinerCommitmentBatchPolicyConfig
 }
 
 func defaultMinerCommitmentPolicyConfig(example bool) MinerCommitmentPolicyConfig {
 	cfg := MinerCommitmentPolicyConfig{
+		SendFund:  true,
 		FeeConfig: defaultFeeConfig(),
 		Batch:     defaultMinerCommitmentBatchPolicyConfig(),
 	}

--- a/venus-sector-manager/modules/impl/commitmgr/commit_processor.go
+++ b/venus-sector-manager/modules/impl/commitmgr/commit_processor.go
@@ -143,7 +143,7 @@ func (c CommitProcessor) Process(ctx context.Context, sectors []core.SectorState
 	}
 
 	if len(infos) == 0 {
-		return fmt.Errorf("no available sectors for aggregating")
+		return fmt.Errorf("no available sector infos for aggregating")
 	}
 
 	sort.Slice(infos, func(i, j int) bool {

--- a/venus-sector-manager/modules/impl/commitmgr/precommit_processor.go
+++ b/venus-sector-manager/modules/impl/commitmgr/precommit_processor.go
@@ -32,7 +32,11 @@ type PreCommitProcessor struct {
 }
 
 func (p PreCommitProcessor) processIndividually(ctx context.Context, sectors []core.SectorState, from address.Address, mid abi.ActorID, l *logging.ZapLogger) {
-	mcfg := p.config.MustMinerConfig(mid)
+	mcfg, err := p.config.MinerConfig(mid)
+	if err != nil {
+		l.Errorf("get miner config for %d: %s", mid, err)
+		return
+	}
 
 	var spec messager.MsgMeta
 	spec.GasOverEstimation = mcfg.Commitment.Pre.GasOverEstimation
@@ -57,6 +61,10 @@ func (p PreCommitProcessor) processIndividually(ctx context.Context, sectors []c
 				return
 			}
 
+			if !mcfg.Commitment.Pre.SendFund {
+				deposit = big.Zero()
+			}
+
 			mcid, err := pushMessage(ctx, from, mid, deposit, miner.Methods.PreCommitSector, p.msgClient, spec, enc.Bytes(), slog)
 			if err != nil {
 				slog.Error("push pre-commit single failed: ", err)
@@ -71,8 +79,6 @@ func (p PreCommitProcessor) processIndividually(ctx context.Context, sectors []c
 }
 
 func (p PreCommitProcessor) Process(ctx context.Context, sectors []core.SectorState, mid abi.ActorID, ctrlAddr address.Address) error {
-	mcfg := p.config.MustMinerConfig(mid)
-
 	// Notice: If a sector in sectors has been sent, it's cid failed should be changed already.
 	plog := log.With("proc", "pre", "miner", mid, "ctrl", ctrlAddr.String(), "len", len(sectors))
 
@@ -83,6 +89,11 @@ func (p PreCommitProcessor) Process(ctx context.Context, sectors []core.SectorSt
 	if !p.EnableBatch(mid) {
 		p.processIndividually(ctx, sectors, ctrlAddr, mid, plog)
 		return nil
+	}
+
+	mcfg, err := p.config.MinerConfig(mid)
+	if err != nil {
+		return fmt.Errorf("get miner config for %d: %w", mid, err)
 	}
 
 	infos := []core.PreCommitEntry{}
@@ -104,9 +115,11 @@ func (p PreCommitProcessor) Process(ctx context.Context, sectors []core.SectorSt
 	params := core.PreCommitSectorBatchParams{}
 
 	deposit := big.Zero()
-	for i := range infos {
-		params.Sectors = append(params.Sectors, *infos[i].Pci)
-		deposit = big.Add(deposit, infos[i].Deposit)
+	if mcfg.Commitment.Pre.SendFund {
+		for i := range infos {
+			params.Sectors = append(params.Sectors, *infos[i].Pci)
+			deposit = big.Add(deposit, infos[i].Deposit)
+		}
 	}
 
 	enc := new(bytes.Buffer)

--- a/venus-sector-manager/modules/impl/commitmgr/precommit_processor.go
+++ b/venus-sector-manager/modules/impl/commitmgr/precommit_processor.go
@@ -112,6 +112,10 @@ func (p PreCommitProcessor) Process(ctx context.Context, sectors []core.SectorSt
 		})
 	}
 
+	if len(infos) == 0 {
+		return fmt.Errorf("no available sector infos for pre commit batching")
+	}
+
 	params := core.PreCommitSectorBatchParams{}
 
 	deposit := big.Zero()


### PR DESCRIPTION
- SnapUp 提交支持可配置的最大重试次数，和不同情况下的重试间隔
- 为 SnapUp 增加随消息发送资金的逻辑，并增加相应的配置开关
- 将原本 Pre & Prove 提交时发送资金的逻辑变为可配置的
- 为批量提交增加空集合的检查