### PR TITLE
feat(log): use local time zone instead of UTC time zone for log output

### DIFF
--- a/venus-worker/.cargo/config.toml
+++ b/venus-worker/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-# Enable local-time feature
-# See https://github.com/time-rs/time/issues/293#issuecomment-1005002386 
-# and https://docs.rs/time/0.3.9/time/index.html#feature-flags.
-rustflags = "--cfg unsound_local_offset"

--- a/venus-worker/.cargo/config.toml
+++ b/venus-worker/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+# Enable local-time feature
+# See https://github.com/time-rs/time/issues/293#issuecomment-1005002386 
+# and https://docs.rs/time/0.3.9/time/index.html#feature-flags.
+rustflags = "--cfg unsound_local_offset"

--- a/venus-worker/Cargo.lock
+++ b/venus-worker/Cargo.lock
@@ -3907,6 +3907,7 @@ dependencies = [
  "serde_repr",
  "signal-hook",
  "storage-proofs-core",
+ "time 0.3.9",
  "tokio",
  "toml",
  "tracing",

--- a/venus-worker/Cargo.toml
+++ b/venus-worker/Cargo.toml
@@ -22,7 +22,7 @@ fil_clock = "0.1"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8.5"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "time", "local-time"] }
 crossterm = "0.20"
 jsonrpc-core = "18"
 jsonrpc-derive = "18"

--- a/venus-worker/Cargo.toml
+++ b/venus-worker/Cargo.toml
@@ -36,6 +36,7 @@ signal-hook = "0.3"
 multiaddr = "0.14.0"
 rand = "0.8.5"
 nix = "0.23"
+time = "0.3"
 
 [dependencies.filecoin-proofs-api]
 version = "11"

--- a/venus-worker/Makefile
+++ b/venus-worker/Makefile
@@ -8,7 +8,8 @@ check-all: check-fmt check-clippy
 # Add `--cfg unsound_local_offset` flag to allow time crate to get the local time zone. \
 See: https://docs.rs/time/0.3.9/time/index.html#feature-flags and \
 https://github.com/time-rs/time/issues/293#issuecomment-1005002386
-build-all: RUSTFLAGS+=--cfg unsound_local_offset
+RUSTFLAGS+=--cfg unsound_local_offset
+
 build-all:
 	cargo build --release
 

--- a/venus-worker/Makefile
+++ b/venus-worker/Makefile
@@ -5,7 +5,10 @@ all: fmt clippy build-all
 check-all: check-fmt check-clippy
 
 build-all:
-	cargo build --release
+# Add `--cfg unsound_local_offset` flag to allow time crate to get the local time zone. \
+See: https://docs.rs/time/0.3.9/time/index.html#feature-flags and \
+https://github.com/time-rs/time/issues/293#issuecomment-1005002386
+	RUSTFLAGS="$(RUSTFLAGS) --cfg unsound_local_offset" cargo build --release
 
 fmt:
 	cargo fmt --all

--- a/venus-worker/Makefile
+++ b/venus-worker/Makefile
@@ -1,14 +1,16 @@
 export GIT_COMMIT=git.$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))
+export RUSTFLAGS
 
 all: fmt clippy build-all
 
 check-all: check-fmt check-clippy
 
-build-all:
 # Add `--cfg unsound_local_offset` flag to allow time crate to get the local time zone. \
 See: https://docs.rs/time/0.3.9/time/index.html#feature-flags and \
 https://github.com/time-rs/time/issues/293#issuecomment-1005002386
-	RUSTFLAGS="$(RUSTFLAGS) --cfg unsound_local_offset" cargo build --release
+build-all: RUSTFLAGS+=--cfg unsound_local_offset
+build-all:
+	cargo build --release
 
 fmt:
 	cargo fmt --all

--- a/venus-worker/src/logging/mod.rs
+++ b/venus-worker/src/logging/mod.rs
@@ -2,9 +2,10 @@
 
 use anyhow::{Context, Result};
 use crossterm::tty::IsTty;
+use time::format_description::well_known::Rfc3339;
 use tracing_subscriber::{
     filter::{self, FilterExt},
-    fmt::{layer, time},
+    fmt::{layer, time::OffsetTime},
     prelude::*,
     registry,
 };
@@ -35,7 +36,7 @@ pub fn init() -> Result<()> {
         .with_ansi(std::io::stderr().is_tty())
         .with_target(true)
         .with_thread_ids(true)
-        .with_timer(time::OffsetTime::local_rfc_3339().context("could not get local offset")?)
+        .with_timer(OffsetTime::local_rfc_3339().unwrap_or_else(|_| OffsetTime::new(time::UtcOffset::UTC, Rfc3339)))
         .with_filter(env_filter.or(worker_env_filter));
 
     registry().with(fmt_layer).init();

--- a/venus-worker/src/logging/mod.rs
+++ b/venus-worker/src/logging/mod.rs
@@ -35,7 +35,7 @@ pub fn init() -> Result<()> {
         .with_ansi(std::io::stderr().is_tty())
         .with_target(true)
         .with_thread_ids(true)
-        .with_timer(time::UtcTime::rfc_3339())
+        .with_timer(time::OffsetTime::local_rfc_3339().context("could not get local offset")?)
         .with_filter(env_filter.or(worker_env_filter));
 
     registry().with(fmt_layer).init();


### PR DESCRIPTION
venus_worker 日志输出时使用本地时区输出时间. 
related issue: #87

经过调研，决定启用 `unsound_local_offset` flag. 根据 [time crate issue #293](https://github.com/time-rs/time/issues/293) 说明: 获取本地时区会调用 `libc::localtime_r`, 而此函数在多线程情况下可能会发生 `data race`. 

我使用 [`tracing_subscriber::fmt::time::OffsetTime`](https://docs.rs/tracing-subscriber/0.3.11/tracing_subscriber/fmt/time/struct.OffsetTime.html) 代替 [`tracing_subscriber::fmt::time::LocalTime`](https://docs.rs/tracing-subscriber/0.3.11/tracing_subscriber/fmt/time/struct.LocalTime.html) 作为日志时间的 Fomater. 
[`tracing_subscriber::fmt::time::OffsetTime`](https://docs.rs/tracing-subscriber/0.3.11/tracing_subscriber/fmt/time/struct.OffsetTime.html) 会在构造时获取本地时区并保存，不会[每次输出日志时间的时候获取时区](https://docs.rs/tracing-subscriber/0.3.11/src/tracing_subscriber/fmt/time/time_crate.rs.html#184)，我们在程序初始化的时候单线程的构造它。 因此我认为能够保证不会发生 `data race` 的问题。