### PR TITLE
chore: makefile of venus-worker now support env FFI_USE_CUDA

### DIFF
--- a/venus-worker/Makefile
+++ b/venus-worker/Makefile
@@ -1,6 +1,17 @@
 export GIT_COMMIT=git.$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))
 export RUSTFLAGS
 
+unexport FFI_USE_CUDA
+unexport VENUS_WORKER_FEATURES
+
+ifdef FFI_USE_CUDA
+	VENUS_WORKER_FEATURES+=cuda
+endif
+
+ifneq ($(strip $(VENUS_WORKER_FEATURES)),)
+	VENUS_WORKER_FEATURE_FLAGS+=--features="$(strip $(VENUS_WORKER_FEATURES))"
+endif
+
 all: fmt clippy build-all
 
 check-all: check-fmt check-clippy
@@ -11,7 +22,7 @@ https://github.com/time-rs/time/issues/293#issuecomment-1005002386
 RUSTFLAGS+=--cfg unsound_local_offset
 
 build-all:
-	cargo build --release
+	cargo build --release $(VENUS_WORKER_FEATURE_FLAGS)
 
 fmt:
 	cargo fmt --all


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
resolved #156 
closed #180 

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
venus-worker 的 Makefile 中增加对已经形成习惯的 `FFI_USE_CUDA` 进行支持


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 具有清晰明确的 commit message / All commits have a clear commit message.
- [ ] 包含必要的测试用例 / This PR has tests for new functionality or change in behaviour
- [ ] 包含必要的指南或文档 / If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included
- [x] 通过必要的检查项 / All checks are green
