### PR TITLE
Feat/0x5459/vc processors dump error response

### DIFF
--- a/docs/zh/QA.md
+++ b/docs/zh/QA.md
@@ -182,3 +182,19 @@ args = ["args1", "args2", "args3"]
 那么出现这种错误，通常表示目标文件不存在，或为空文件。
 
 例如，在 `WindowPoSt` 场景，如果没有准备好参数文件或密钥文件。
+
+## Q: `vc_processors::core::ext::producer: failed to unmarshal response string` 是什么错误？ 如何处理？
+
+**A**：发生这种错误是因为外部处理器产生了错误格式的响应。可以通过 venus-worker 提供的命令运行时的开启或关闭 dump 功能，查看错误格式的响应。
+
+开启 dump
+```
+venus-worker worker --config="path/to/your_config_file.toml" enable_dump --child_pid=<target_ext_processor_pid> --dump_dir="path/to/dump_dir"
+```
+
+关闭 dump
+```
+venus-worker worker --config="path/to/your_config_file.toml" disable_dump --child_pid=<target_ext_processor_pid>
+```
+
+可根据 dump 文件进行 debug。

--- a/venus-worker/Cargo.lock
+++ b/venus-worker/Cargo.lock
@@ -2067,6 +2067,15 @@ dependencies = [
 
 [[package]]
 name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
@@ -3739,6 +3748,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers 0.0.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,7 +3787,7 @@ checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
- "matchers",
+ "matchers 0.1.0",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -3755,6 +3796,29 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b48778c2d401c6a7fcf38a0e3c55dc8e8e753cbd381044a8cdb6fd69a29f53"
+dependencies = [
+ "lazy_static",
+ "tracing-core",
+ "tracing-subscriber 0.2.25",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
+dependencies = [
+ "lazy_static",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3862,6 +3926,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom 0.2.3",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3892,8 +3966,11 @@ dependencies = [
  "serde",
  "serde_json",
  "storage-proofs-core",
+ "tempfile",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.10",
+ "tracing-test",
+ "uuid",
 ]
 
 [[package]]
@@ -3946,7 +4023,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.10",
  "vc-processors",
 ]
 

--- a/venus-worker/Cargo.toml
+++ b/venus-worker/Cargo.toml
@@ -23,7 +23,7 @@ base64-serde = "0.6"
 base64 = "0.13"
 forest_json_utils = "0.1"
 forest_address = "0.3"
-forest_cid = { version = "0.3", features = ["json"]}
+forest_cid = { version = "0.3", features = ["json"] }
 fil_clock = "0.1"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"

--- a/venus-worker/src/bin/venus-worker/worker/mod.rs
+++ b/venus-worker/src/bin/venus-worker/worker/mod.rs
@@ -58,7 +58,7 @@ pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
                 .required(true)
                 .help("Specify the dump directory"),
         ])
-        .help("Enable external processor error response dump for debugging");
+        .help("Enable external processor error format response dump for debugging");
 
     let disable_dump_cmd = SubCommand::with_name("disable_dump")
         .arg(
@@ -68,7 +68,7 @@ pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
                 .required(true)
                 .help("Specify external processor pid"),
         )
-        .help("Disable external processor error response dump");
+        .help("Disable external processor error format response dump");
 
     SubCommand::with_name(SUB_CMD_NAME)
         .setting(AppSettings::ArgRequiredElseHelp)

--- a/venus-worker/src/bin/venus-worker/worker/mod.rs
+++ b/venus-worker/src/bin/venus-worker/worker/mod.rs
@@ -133,9 +133,9 @@ pub fn submatch(subargs: &ArgMatches<'_>) -> Result<()> {
 
         ("enable_dump", Some(m)) => {
             let child_pid = value_t!(m, "child_pid", u32)?;
-            let dump_dir: PathBuf = value_t!(m, "dump_dir", String)?.into();
+            let dump_dir = value_t!(m, "dump_dir", PathBuf)?;
             if !dump_dir.is_dir() {
-                return Err(anyhow!("{} is not a directory", dump_dir.display()));
+                return Err(anyhow!("'{}' is not a directory", dump_dir.display()));
             }
             let dump_dir = fs::canonicalize(dump_dir)?;
             let env_name = vc_processors::core::ext::dump_error_resp_env(child_pid);

--- a/venus-worker/src/rpc/worker/mod.rs
+++ b/venus-worker/src/rpc/worker/mod.rs
@@ -42,4 +42,12 @@ pub trait Worker {
     /// resume specific worker, with given state, if any
     #[rpc(name = "VenusWorker.WorkerResume")]
     fn worker_resume(&self, index: usize, set_to: Option<String>) -> Result<bool>;
+
+    /// set os environment
+    #[rpc(name = "VenusWorker.WorkerSetEnv")]
+    fn worker_set_env(&self, name: String, value: String) -> Result<()>;
+
+    /// remove os environment
+    #[rpc(name = "VenusWorker.WorkerRemoveEnv")]
+    fn worker_remove_env(&self, name: String) -> Result<()>;
 }

--- a/venus-worker/src/run.rs
+++ b/venus-worker/src/run.rs
@@ -252,36 +252,36 @@ macro_rules! construct_sub_processor {
     ($field:ident, $cfg:ident, $locks:ident) => {
         if let Some(ext) = $cfg.processors.$field.as_ref() {
             let proc = processor::external::ExtProcessor::build(ext, $locks.clone())?;
-            Box::new(proc)
+            Arc::new(proc)
         } else {
-            Box::new(BuiltinProcessor::default())
+            Arc::new(BuiltinProcessor::default())
         }
     };
 }
 
 fn start_processors(cfg: &config::Config, locks: &Arc<resource::Pool>) -> Result<GloablProcessors> {
-    let tree_d: processor::BoxedTreeDProcessor = construct_sub_processor!(tree_d, cfg, locks);
+    let tree_d: processor::ArcTreeDProcessor = construct_sub_processor!(tree_d, cfg, locks);
 
-    let pc1: processor::BoxedPC1Processor = construct_sub_processor!(pc1, cfg, locks);
+    let pc1: processor::ArcPC1Processor = construct_sub_processor!(pc1, cfg, locks);
 
-    let pc2: processor::BoxedPC2Processor = construct_sub_processor!(pc2, cfg, locks);
+    let pc2: processor::ArcPC2Processor = construct_sub_processor!(pc2, cfg, locks);
 
-    let c2: processor::BoxedC2Processor = construct_sub_processor!(c2, cfg, locks);
+    let c2: processor::ArcC2Processor = construct_sub_processor!(c2, cfg, locks);
 
-    let snap_encode: processor::BoxedSnapEncodeProcessor = construct_sub_processor!(snap_encode, cfg, locks);
+    let snap_encode: processor::ArcSnapEncodeProcessor = construct_sub_processor!(snap_encode, cfg, locks);
 
-    let snap_prove: processor::BoxedSnapProveProcessor = construct_sub_processor!(snap_prove, cfg, locks);
+    let snap_prove: processor::ArcSnapProveProcessor = construct_sub_processor!(snap_prove, cfg, locks);
 
-    let transfer: processor::BoxedTransferProcessor = construct_sub_processor!(transfer, cfg, locks);
+    let transfer: processor::ArcTransferProcessor = construct_sub_processor!(transfer, cfg, locks);
 
     Ok(GloablProcessors {
-        tree_d: Arc::new(tree_d),
-        pc1: Arc::new(pc1),
-        pc2: Arc::new(pc2),
-        c2: Arc::new(c2),
-        snap_encode: Arc::new(snap_encode),
-        snap_prove: Arc::new(snap_prove),
-        transfer: Arc::new(transfer),
+        tree_d,
+        pc1,
+        pc2,
+        c2,
+        snap_encode,
+        snap_prove,
+        transfer,
     })
 }
 

--- a/venus-worker/src/sealing/processor/mod.rs
+++ b/venus-worker/src/sealing/processor/mod.rs
@@ -1,5 +1,7 @@
 //! processor abstractions & implementations for sealing
 
+use std::sync::Arc;
+
 pub use vc_processors::{
     builtin::tasks::{
         SnapEncode as SnapEncodeInput, SnapProve as SnapProveInput, Transfer as TransferInput, TransferItem, TransferOption, TransferRoute,
@@ -13,11 +15,11 @@ pub mod external;
 mod safe;
 pub use safe::*;
 
-pub type BoxedProcessor<I> = Box<dyn Processor<I>>;
-pub type BoxedTreeDProcessor = BoxedProcessor<TreeDInput>;
-pub type BoxedPC1Processor = BoxedProcessor<PC1Input>;
-pub type BoxedPC2Processor = BoxedProcessor<PC2Input>;
-pub type BoxedC2Processor = BoxedProcessor<C2Input>;
-pub type BoxedSnapEncodeProcessor = BoxedProcessor<SnapEncodeInput>;
-pub type BoxedSnapProveProcessor = BoxedProcessor<SnapProveInput>;
-pub type BoxedTransferProcessor = BoxedProcessor<TransferInput>;
+pub type ArcProcessor<I> = Arc<dyn Processor<I>>;
+pub type ArcTreeDProcessor = ArcProcessor<TreeDInput>;
+pub type ArcPC1Processor = ArcProcessor<PC1Input>;
+pub type ArcPC2Processor = ArcProcessor<PC2Input>;
+pub type ArcC2Processor = ArcProcessor<C2Input>;
+pub type ArcSnapEncodeProcessor = ArcProcessor<SnapEncodeInput>;
+pub type ArcSnapProveProcessor = ArcProcessor<SnapProveInput>;
+pub type ArcTransferProcessor = ArcProcessor<TransferInput>;

--- a/venus-worker/src/sealing/service.rs
+++ b/venus-worker/src/sealing/service.rs
@@ -102,23 +102,23 @@ impl Worker for ServiceImpl {
         println!("{}, {}", name, value);
         // Avoid panic of set_var function
         // See: https://doc.rust-lang.org/stable/std/env/fn.set_var.html#panics
-        if !(name.is_empty() || name.contains(['=', '\0']) || value.contains('\0')) {
-            if std::panic::catch_unwind(|| env::set_var(name, value)).is_ok() {
-                return Ok(());
-            }
+        if name.is_empty()
+            || name.contains(['=', '\0'])
+            || value.contains('\0')
+            || std::panic::catch_unwind(|| env::set_var(name, value)).is_err()
+        {
+            return Err(Error::invalid_params("invalid environment variable name or value"));
         }
-        Err(Error::invalid_params("invalid environment variable name or value"))
+        Ok(())
     }
 
     fn worker_remove_env(&self, name: String) -> Result<()> {
         // Avoid panic of remove_var function
         // See: https://doc.rust-lang.org/std/env/fn.remove_var.html#panics
-        if !name.is_empty() && !name.contains(['=', '\0']) {
-            if std::panic::catch_unwind(|| env::remove_var(name)).is_ok() {
-                return Ok(());
-            }
+        if name.is_empty() || name.contains(['=', '\0']) || std::panic::catch_unwind(|| env::remove_var(name)).is_err() {
+            return Err(Error::invalid_params("invalid environment variable name"));
         }
-        Err(Error::invalid_params("invalid environment variable name"))
+        Ok(())
     }
 }
 

--- a/venus-worker/src/sealing/service.rs
+++ b/venus-worker/src/sealing/service.rs
@@ -99,7 +99,6 @@ impl Worker for ServiceImpl {
     }
 
     fn worker_set_env(&self, name: String, value: String) -> Result<()> {
-        println!("{}, {}", name, value);
         // Avoid panic of set_var function
         // See: https://doc.rust-lang.org/stable/std/env/fn.set_var.html#panics
         if name.is_empty()

--- a/venus-worker/src/watchdog.rs
+++ b/venus-worker/src/watchdog.rs
@@ -14,8 +14,8 @@ use crate::{
     rpc::sealer::SealerClient,
     sealing::{
         processor::{
-            BoxedC2Processor, BoxedPC1Processor, BoxedPC2Processor, BoxedSnapEncodeProcessor, BoxedSnapProveProcessor,
-            BoxedTransferProcessor, BoxedTreeDProcessor,
+            ArcC2Processor, ArcPC1Processor, ArcPC2Processor, ArcSnapEncodeProcessor, ArcSnapProveProcessor, ArcTransferProcessor,
+            ArcTreeDProcessor,
         },
         resource::Pool,
     },
@@ -51,13 +51,13 @@ pub struct GlobalModules {
 
 #[derive(Clone)]
 pub struct GloablProcessors {
-    pub tree_d: Arc<BoxedTreeDProcessor>,
-    pub pc1: Arc<BoxedPC1Processor>,
-    pub pc2: Arc<BoxedPC2Processor>,
-    pub c2: Arc<BoxedC2Processor>,
-    pub snap_encode: Arc<BoxedSnapEncodeProcessor>,
-    pub snap_prove: Arc<BoxedSnapProveProcessor>,
-    pub transfer: Arc<BoxedTransferProcessor>,
+    pub tree_d: ArcTreeDProcessor,
+    pub pc1: ArcPC1Processor,
+    pub pc2: ArcPC2Processor,
+    pub c2: ArcC2Processor,
+    pub snap_encode: ArcSnapEncodeProcessor,
+    pub snap_prove: ArcSnapProveProcessor,
+    pub transfer: ArcTransferProcessor,
 }
 
 impl Module for Box<dyn Module> {

--- a/venus-worker/vc-processors/Cargo.toml
+++ b/venus-worker/vc-processors/Cargo.toml
@@ -23,6 +23,7 @@ tracing = "0.1"
 anyhow = "1"
 crossbeam-channel = { version = "0.5", optional = true }
 memmap = { version = "0.7", optional = true }
+uuid = { version = "1.1", features = ["v4", "fast-rng"] }
 
 [dependencies.filecoin-proofs]
 version = "11.1"
@@ -42,9 +43,11 @@ optional = true
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-test = "0.1"
 rand = "0.8"
 pretty_assertions = "1.2"
 hex = "0.4"
+tempfile = "3"
 
 [features]
 default = []

--- a/venus-worker/vc-processors/src/core/ext/mod.rs
+++ b/venus-worker/vc-processors/src/core/ext/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "ext-producer")]
 mod producer;
 #[cfg(feature = "ext-producer")]
-pub use producer::{BoxedFinalizeHook, BoxedPrepareHook, Producer, ProducerBuilder};
+pub use producer::{dump_error_resp_env, BoxedFinalizeHook, BoxedPrepareHook, Producer, ProducerBuilder};
 
 mod consumer;
 pub use consumer::run as run_consumer;

--- a/venus-worker/vc-processors/src/core/ext/producer.rs
+++ b/venus-worker/vc-processors/src/core/ext/producer.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
-use std::env::vars;
+use std::env::{self, vars};
+use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::{
     atomic::{AtomicU64, Ordering},
@@ -14,11 +15,21 @@ use anyhow::{anyhow, Context, Result};
 use crossbeam_channel::{after, bounded, never, select, Sender};
 use serde_json::{from_str, to_string};
 use tracing::{debug, error, info, warn, warn_span};
+use uuid::Uuid;
 
 use super::{ready_msg, Request, Response};
 use crate::core::{Processor, Task};
 
-pub fn start_response_handler<T: Task>(stdout: ChildStdout, out_txes: Arc<Mutex<HashMap<u64, Sender<Response<T::Output>>>>>) -> Result<()> {
+/// Dump error resp env key
+pub fn dump_error_resp_env(pid: u32) -> String {
+    format!("DUMP_ERR_RESP_{}", pid)
+}
+
+pub fn start_response_handler<T: Task>(
+    pid: u32,
+    stdout: ChildStdout,
+    out_txes: Arc<Mutex<HashMap<u64, Sender<Response<T::Output>>>>>,
+) -> Result<()> {
     let mut reader = BufReader::new(stdout);
     let mut line_buf = String::new();
 
@@ -34,7 +45,7 @@ pub fn start_response_handler<T: Task>(stdout: ChildStdout, out_txes: Arc<Mutex<
         let resp: Response<T::Output> = match from_str(line_buf.as_str()) {
             Ok(r) => r,
             Err(e) => {
-                error!("failed to unmarshal response string: {:?}", e);
+                dump(&DumpType::from_env(pid), e, line_buf.as_str());
                 continue;
             }
         };
@@ -45,6 +56,74 @@ pub fn start_response_handler<T: Task>(stdout: ChildStdout, out_txes: Arc<Mutex<
             let _ = out_tx.send(resp);
         }
     }
+}
+
+/// Dump type of the error response of the processor
+#[derive(Debug, Clone)]
+enum DumpType {
+    /// Dump error response fragments to the log
+    ToLog,
+    /// Dump error response fragments to the file
+    ToFile(PathBuf),
+}
+
+impl DumpType {
+    fn from_env(pid: u32) -> Self {
+        match env::var(dump_error_resp_env(pid)) {
+            Ok(path) => Self::ToFile(path.into()),
+            Err(_) => Self::ToLog,
+        }
+    }
+}
+
+fn dump(dt: &DumpType, serde_err: serde_json::Error, data: &str) {
+    #[inline]
+    fn truncate(data: &str) -> String {
+        const TRUNCATE_SIZE: usize = 100;
+
+        if data.len() <= TRUNCATE_SIZE {
+            return data.to_string();
+        }
+
+        let trunc_len = (0..TRUNCATE_SIZE + 1).rposition(|index| data.is_char_boundary(index)).unwrap_or(0);
+        format!("{}...", &data[..trunc_len])
+    }
+
+    match dt {
+        DumpType::ToLog => {
+            error!(serde_json_err=%serde_err, "failed to unmarshal response string: '{}'", truncate(data));
+        }
+        DumpType::ToFile(dir) => match dump_to_file(dir, data.as_bytes()) {
+            Ok(dump_file_path) => {
+                error!(serde_json_err=%serde_err,
+                    "failed to unmarshal response string. dump file '{}' generated",
+                    dump_file_path.display()
+                )
+            }
+            Err(e) => {
+                error!(serde_json_err=%serde_err, "failed to unmarshal response string; failed to generate dump file: {}", e);
+            }
+        },
+    }
+}
+
+fn dump_to_file(dir: impl AsRef<Path>, data: &[u8]) -> Result<PathBuf> {
+    #[inline]
+    fn ensure_dir(dir: &Path) -> Result<()> {
+        if !dir.exists() {
+            fs::create_dir_all(dir).with_context(|| format!("create directory '{}' for dump files", dir.display()))?;
+        } else if !dir.is_dir() {
+            return Err(anyhow!("{} is not directory", dir.display()));
+        }
+        Ok(())
+    }
+
+    let dir = dir.as_ref();
+    ensure_dir(dir)?;
+    let filename = format!("{}.json", Uuid::new_v4().as_simple());
+    let path = dir.join(&filename);
+    fs::write(&path, data)?;
+    Ok(path)
 }
 
 pub struct Hooks<P, F> {
@@ -220,9 +299,10 @@ where
         let stdout = self.stdout.take().context("stdout lost")?;
 
         let out_txes = self.out_txes.clone();
+        let pid = self.child_pid();
         thread::spawn(move || {
             let _span = warn_span!("response handler");
-            if let Err(e) = start_response_handler::<T>(stdout, out_txes) {
+            if let Err(e) = start_response_handler::<T>(pid, stdout, out_txes) {
                 error!("unexpected: {:?}", e);
             }
         });
@@ -303,5 +383,74 @@ impl<F: FnMut()> Drop for Defer<F> {
         if self.0 {
             (self.1)();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use pretty_assertions::assert_eq;
+    use tracing_test::traced_test;
+
+    use super::{dump, dump_to_file, DumpType};
+
+    fn dummy_serde_err() -> serde_json::Error {
+        serde_json::from_str::<Vec<u8>>("DUMMY").unwrap_err()
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_dump_to_log() {
+        let cases = vec![
+            ("abcdefg".to_string(), format!("'{}'", "abcdefg")),
+            ("一二三四五123".to_string(), format!("'{}'", "一二三四五123")),
+            ("a".repeat(100), format!("'{}'", "a".repeat(100))),
+            ("a".repeat(101), format!("'{}...'", "a".repeat(100))),
+            ("a".repeat(200), format!("'{}...'", "a".repeat(100))),
+            ("💗".repeat(100), format!("'{}...'", "💗".repeat(25))),
+        ];
+
+        for (data, expected_log) in cases {
+            dump(&DumpType::ToLog, dummy_serde_err(), &data);
+            assert!(logs_contain(&expected_log));
+        }
+    }
+
+    #[test]
+    fn test_dump_to_file() {
+        use tempfile::tempdir;
+
+        let tmpdir = tempdir().expect("couldn't create temp dir");
+
+        let dumpfile = dump_to_file(tmpdir.path(), "hello world".as_bytes());
+        assert!(dumpfile.is_ok(), "dump_to_file: {:?}", dumpfile.err());
+        let dumpfile = dumpfile.unwrap();
+        assert_eq!(tmpdir.path(), dumpfile.parent().unwrap());
+        assert_eq!("hello world", fs::read_to_string(dumpfile).unwrap());
+    }
+
+    #[test]
+    fn test_dump_to_file_when_dir_not_exist() {
+        use tempfile::tempdir;
+
+        let tmpdir = tempdir().expect("couldn't create temp dir");
+        let not_exist_dir = tmpdir.path().join("test");
+
+        let dumpfile = dump_to_file(&not_exist_dir, "hello world".as_bytes());
+        assert!(dumpfile.is_ok(), "dump_to_file: {:?}", dumpfile.err());
+        let dumpfile = dumpfile.unwrap();
+        assert_eq!(not_exist_dir, dumpfile.parent().unwrap());
+        assert_eq!("hello world", fs::read_to_string(dumpfile).unwrap());
+    }
+
+    #[test]
+    fn test_dump_to_file_when_not_dir() {
+        use tempfile::tempdir;
+        let tmpdir = tempdir().expect("couldn't create temp dir");
+        let tmpfile = tmpdir.path().join("test.json");
+        fs::write(&tmpfile, "oops").unwrap();
+
+        assert!(dump_to_file(&tmpfile, "hello world".as_bytes()).is_err());
     }
 }

--- a/venus-worker/vc-processors/src/core/ext/producer.rs
+++ b/venus-worker/vc-processors/src/core/ext/producer.rs
@@ -91,20 +91,20 @@ fn dump(dt: &DumpType, child_pid: u32, data: &str) {
 
     match dt {
         DumpType::ToLog => {
-            error!(child_pid = child_pid, "failed to unmarshal response string: '{}'", truncate(data));
+            error!(child_pid = child_pid, "failed to unmarshal response string: '{}'.", truncate(data));
         }
         DumpType::ToFile(dir) => match dump_to_file(child_pid, dir, data.as_bytes()) {
             Ok(dump_file_path) => {
                 error!(
                     child_pid = child_pid,
-                    "failed to unmarshal response string. dump file '{}' generated",
+                    "failed to unmarshal response string. dump file '{}' generated.",
                     dump_file_path.display()
                 )
             }
             Err(e) => {
                 error!(
                     child_pid = child_pid,
-                    "failed to unmarshal response string; failed to generate dump file: {}", e
+                    "failed to unmarshal response string; failed to generate dump file: '{}'.", e
                 );
             }
         },
@@ -117,7 +117,7 @@ fn dump_to_file(child_pid: u32, dir: impl AsRef<Path>, data: &[u8]) -> Result<Pa
         if !dir.exists() {
             fs::create_dir_all(dir).with_context(|| format!("create directory '{}' for dump files", dir.display()))?;
         } else if !dir.is_dir() {
-            return Err(anyhow!("{} is not directory", dir.display()));
+            return Err(anyhow!("'{}' is not directory", dir.display()));
         }
         Ok(())
     }

--- a/venus-worker/vc-processors/src/core/ext/producer.rs
+++ b/venus-worker/vc-processors/src/core/ext/producer.rs
@@ -58,12 +58,12 @@ pub fn start_response_handler<T: Task>(
     }
 }
 
-/// Dump type of the error response of the processor
+/// Dump type of the error format response of the processor
 #[derive(Debug, Clone)]
 enum DumpType {
-    /// Dump error response fragments to the log
+    /// Dump error format response fragments to the log
     ToLog,
-    /// Dump error response fragments to the file
+    /// Dump error format response to the file
     ToFile(PathBuf),
 }
 


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
resolve #256
## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
* vc-processors 接收到错误的 ext-processor 响应时可 dump 错误响应
* worker rpc 新增 `worker_set_env`, `worker_remove_env` 用于运行时设置和移除环境变量
* worker cli 新增 `enable_dump`, `disable_dump` 用于开启和关闭 ext-processor dump 功能

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 具有清晰明确的 commit message / All commits have a clear commit message.
- [x] 包含必要的测试用例 / This PR has tests for new functionality or change in behaviour
- [x] 包含必要的指南或文档 / If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included
- [x] 通过必要的检查项 / All checks are green
