### PR TITLE
feat(worker): support for NUMA aware when creating PC1 label memory

### DIFF
--- a/docs/zh/05.快速启用.md
+++ b/docs/zh/05.快速启用.md
@@ -132,7 +132,7 @@
       -p, --pat <shm_numa_dir_pattern>    Specify the shared memory directory pattern [default: filecoin-proof-
                                           label/numa_$NUMA_NODE_INDEX]
       -s, --size <size>                   Specify the size of each shm file. (e.g., 1B, 2KB, 3kiB, 1MB, 2MiB, 3GB, 1GiB,
-                                          ...) [possible values: 32GiB, 64GiB]
+                                          ...)
    ```
    Example:
    ```

--- a/docs/zh/05.快速启用.md
+++ b/docs/zh/05.快速启用.md
@@ -129,8 +129,6 @@
    OPTIONS:
       -n, --node <numa_node_index>        Specify the numa node
       -c, --num <number_of_files>         Specify the number of shm files to be created
-      -p, --pat <shm_numa_dir_pattern>    Specify the shared memory directory pattern [default: filecoin-proof-
-                                          label/numa_$NUMA_NODE_INDEX]
       -s, --size <size>                   Specify the size of each shm file. (e.g., 1B, 2KB, 3kiB, 1MB, 2MiB, 3GB, 1GiB,
                                           ...)
    ```

--- a/docs/zh/05.快速启用.md
+++ b/docs/zh/05.快速启用.md
@@ -109,14 +109,47 @@
    ```
 
    命令初始化数据目录。
+3. 创建共享内存文件 (可选)
+   
+   在 PC1 阶段 `rust-fil-proofs` 会申请两块和扇区大小一致的大块内存。 这两块内存如果和 PC1 工作线程在同一 NUMA 节点会有效提升性能。
 
-3. 规划用于各阶段的CPU核、numa 区域等配置。
+   经过测试，即便配置了 [numa_preferred](./03.venus-worker%E7%9A%84%E9%85%8D%E7%BD%AE%E8%A7%A3%E6%9E%90.md#processorsstage_name) 在运行一段时间后，系统也经常会跨 NUMA 节点申请这两块内存。使用我们改造后的 [rust-fil-proofs](https://github.com/ipfs-force-community/rust-fil-proofs/tree/force/master_v11.1.1) (当前版本的 venus-worker 已支持) 可以使用预先创建好的和扇区大小一致的共享内存，该共享内存仅供上述 PC1 阶段的两大块内存的需求使用。可以一定程度上解决问题。
+
+   Usage:
+   ```
+   venus-worker-store-shm-init
+
+   USAGE:
+      venus-worker store shm-init [OPTIONS] --node <numa_node_index> --num <number_of_files> --size <size>
+
+   FLAGS:
+      -h, --help       Prints help information
+      -V, --version    Prints version information
+
+   OPTIONS:
+      -n, --node <numa_node_index>        Specify the numa node
+      -c, --num <number_of_files>         Specify the number of shm files to be created
+      -p, --pat <shm_numa_dir_pattern>    Specify the shared memory directory pattern [default: filecoin-proof-
+                                          label/numa_$NUMA_NODE_INDEX]
+      -s, --size <size>                   Specify the size of each shm file. (e.g., 1B, 2KB, 3kiB, 1MB, 2MiB, 3GB, 1GiB,
+                                          ...) [possible values: 32GiB, 64GiB]
+   ```
+   Example:
+   ```
+   # 在 NUMA 节点 0 上创建 4 个大小为 32GiB 的共享内存
+   ./dist/bin/venus-worker store shm-init --node=0 --num=4 --size=32GiB
+
+   # 在 NUMA 节点 1 上创建 4 个大小为 32GiB 的共享内存
+   ./dist/bin/venus-worker store shm-init --node=1 --num=4 --size=32GiB
+   ```
+
+4. 规划用于各阶段的CPU核、numa 区域等配置。
 
    按需完成配置文件。
 
    配置项、作用、配置方法可以参考文档 `03.venus-worker的配置解析`。
 
-4. 使用
+5. 使用
 
    ```
    /path/to/venus-worker daemon -c /path/to/venus-worker.toml

--- a/venus-worker/Cargo.lock
+++ b/venus-worker/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "filecoin-hashers"
 version = "6.1.1"
-source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#ef44daad270d740e1486aa41020edde73e4da88a"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1138,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "11.1.1"
-source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#ef44daad270d740e1486aa41020edde73e4da88a"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "fr32"
 version = "4.1.1"
-source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#ef44daad270d740e1486aa41020edde73e4da88a"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "sha2raw"
 version = "6.1.1"
-source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#ef44daad270d740e1486aa41020edde73e4da88a"
 dependencies = [
  "block-buffer 0.9.0",
  "byteorder 1.4.3",
@@ -3338,7 +3338,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-proofs-core"
 version = "11.1.1"
-source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#ef44daad270d740e1486aa41020edde73e4da88a"
 dependencies = [
  "aes",
  "anyhow",
@@ -3379,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-porep"
 version = "11.1.1"
-source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#ef44daad270d740e1486aa41020edde73e4da88a"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-post"
 version = "11.1.1"
-source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#ef44daad270d740e1486aa41020edde73e4da88a"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3451,7 +3451,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-update"
 version = "11.1.1"
-source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#ef44daad270d740e1486aa41020edde73e4da88a"
 dependencies = [
  "anyhow",
  "bellperson",

--- a/venus-worker/Cargo.lock
+++ b/venus-worker/Cargo.lock
@@ -507,6 +507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
 name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,9 +1118,8 @@ dependencies = [
 
 [[package]]
 name = "filecoin-hashers"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5459189a6cd4eff6e425be7295e5e083dee3c9b1508291b955869f3b6b24f0cd"
+version = "6.1.1"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1133,8 +1138,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "11.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e956a3235e86b88bfb3ffedf700ab1ff17145ac8d3936cd57d8bdef664d6a5d0"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1148,7 +1152,7 @@ dependencies = [
  "ff",
  "fil_logger",
  "filecoin-hashers",
- "fr32",
+ "fr32 4.1.1",
  "generic-array 0.14.4",
  "group",
  "hex",
@@ -1183,7 +1187,7 @@ dependencies = [
  "blstrs",
  "filecoin-hashers",
  "filecoin-proofs",
- "fr32",
+ "fr32 4.1.0",
  "lazy_static",
  "serde",
  "storage-proofs-core",
@@ -1338,6 +1342,20 @@ name = "fr32"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355338c73ad12186e0f99c563f2e5666f837d5c04edfd4302e7b89b356b8c86e"
+dependencies = [
+ "anyhow",
+ "bellperson",
+ "blstrs",
+ "byte-slice-cast",
+ "byteorder 1.4.3",
+ "ff",
+ "thiserror",
+]
+
+[[package]]
+name = "fr32"
+version = "4.1.1"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3222,9 +3240,8 @@ dependencies = [
 
 [[package]]
 name = "sha2raw"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af99229b0c723332974a9aa0cac312f5bd8372ed7510a7159d9a91da8051e10"
+version = "6.1.1"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
 dependencies = [
  "block-buffer 0.9.0",
  "byteorder 1.4.3",
@@ -3321,8 +3338,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-proofs-core"
 version = "11.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bff040dcf0834917f69db391f4fb5e72d43c7d5cb90b5bbd4ae9d6b744a894"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
 dependencies = [
  "aes",
  "anyhow",
@@ -3335,9 +3351,10 @@ dependencies = [
  "config",
  "ff",
  "filecoin-hashers",
- "fr32",
+ "fr32 4.1.1",
  "fs2",
  "generic-array 0.14.4",
+ "glob",
  "hex",
  "itertools 0.9.0",
  "lazy_static",
@@ -3362,8 +3379,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-porep"
 version = "11.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395dd7a7802d002def493315e0ec8e6bda274c7a31406c5104dfc1a19fbfc7b3"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3377,8 +3393,9 @@ dependencies = [
  "ff",
  "fil_logger",
  "filecoin-hashers",
- "fr32",
+ "fr32 4.1.1",
  "generic-array 0.14.4",
+ "glob",
  "hex",
  "hwloc",
  "lazy_static",
@@ -3394,6 +3411,7 @@ dependencies = [
  "pretty_assertions 0.6.1",
  "rand 0.8.5",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "sha2 0.9.5",
@@ -3405,8 +3423,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-post"
 version = "11.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e868618ef3b6968928924a38410e816752799ce26242799497bd1461b6228a22"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3417,7 +3434,7 @@ dependencies = [
  "crossbeam",
  "ff",
  "filecoin-hashers",
- "fr32",
+ "fr32 4.1.1",
  "generic-array 0.14.4",
  "hex",
  "log",
@@ -3434,8 +3451,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-update"
 version = "11.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e69871eb1a083fa5a3db211981d5959f549708bb578b0e0e9961467384d31d1"
+source = "git+https://github.com/ipfs-force-community/rust-fil-proofs?branch=force/master_v11.1.1#51ca98ce9dfaa60e8e0cec0d5b152acd5f0727a2"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3449,7 +3465,7 @@ dependencies = [
  "ff",
  "fil_logger",
  "filecoin-hashers",
- "fr32",
+ "fr32 4.1.1",
  "generic-array 0.14.4",
  "hex",
  "lazy_static",
@@ -3963,6 +3979,7 @@ dependencies = [
  "filecoin-proofs-api",
  "forest_address",
  "hex",
+ "lazy_static",
  "memmap",
  "pretty_assertions 1.2.1",
  "rand 0.8.5",
@@ -3996,6 +4013,7 @@ dependencies = [
  "base64",
  "base64-serde",
  "byte-unit",
+ "bytesize",
  "cgroups-rs",
  "clap",
  "crossbeam-channel",
@@ -4012,6 +4030,7 @@ dependencies = [
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-http-server",
+ "libc",
  "multiaddr",
  "nix",
  "pretty_assertions 1.2.1",

--- a/venus-worker/Cargo.lock
+++ b/venus-worker/Cargo.lock
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "vc-processors"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/venus-worker/Cargo.toml
+++ b/venus-worker/Cargo.toml
@@ -87,6 +87,8 @@ cuda = ["vc-processors/fil-proofs-cuda"]
 [patch.crates-io]
 filecoin-hashers = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "filecoin-hashers", branch = "force/master_v11.1.1"}
 filecoin-proofs = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "filecoin-proofs", branch = "force/master_v11.1.1" }
+fr32 = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "fr32", branch = "force/master_v11.1.1" }
+sha2raw = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "sha2raw", branch = "force/master_v11.1.1" }
 storage-proofs-core = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "storage-proofs-core", branch = "force/master_v11.1.1" }
 storage-proofs-porep = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "storage-proofs-porep", branch = "force/master_v11.1.1" }
 storage-proofs-post = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "storage-proofs-post", branch = "force/master_v11.1.1" }

--- a/venus-worker/Cargo.toml
+++ b/venus-worker/Cargo.toml
@@ -41,6 +41,8 @@ multiaddr = "0.14.0"
 rand = "0.8.5"
 nix = "0.23"
 time = "0.3"
+bytesize = "1.1"
+libc = "0.2"
 
 [dependencies.reqwest]
 version = "0.11"
@@ -81,3 +83,11 @@ humantime = "2.1"
 [features]
 default = ["vc-processors/builtin", "vc-processors/ext-producer"]
 cuda = ["vc-processors/fil-proofs-cuda"]
+
+[patch.crates-io]
+filecoin-hashers = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "filecoin-hashers", branch = "force/master_v11.1.1"}
+filecoin-proofs = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "filecoin-proofs", branch = "force/master_v11.1.1" }
+storage-proofs-core = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "storage-proofs-core", branch = "force/master_v11.1.1" }
+storage-proofs-porep = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "storage-proofs-porep", branch = "force/master_v11.1.1" }
+storage-proofs-post = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "storage-proofs-post", branch = "force/master_v11.1.1" }
+storage-proofs-update = { git = "https://github.com/ipfs-force-community/rust-fil-proofs", package = "storage-proofs-update", branch = "force/master_v11.1.1" }

--- a/venus-worker/src/bin/venus-worker/store.rs
+++ b/venus-worker/src/bin/venus-worker/store.rs
@@ -4,7 +4,7 @@ use tracing::{error, info};
 
 use venus_worker::{objstore::filestore::FileStore, store::Store};
 
-#[cfg(target_os = "Linux")]
+#[cfg(target_os = "linux")]
 mod shm;
 
 pub const SUB_CMD_NAME: &str = "store";
@@ -29,22 +29,29 @@ pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
     );
 
     let shm_init_cmd = SubCommand::with_name("shm-init").args(&[
-        Arg::with_name("numa_node")
+        Arg::with_name("numa_node_index")
             .long("node")
+            .short("n")
+            .required(true)
             .takes_value(true)
             .help("Specify the numa node"),
         Arg::with_name("size")
+            .long("size")
             .short("s")
+            .required(true)
             .takes_value(true)
-            .possible_values(&["32Gib", "64Gib"])
+            .possible_values(&["32GiB", "64GiB"])
             .help("Specify the size of each shm file. (e.g., 1B, 2KB, 3kiB, 1MB, 2MiB, 3GB, 1GiB, ...)"),
         Arg::with_name("number_of_files")
             .long("num")
-            .short("n")
+            .short("c")
+            .required(true)
             .takes_value(true)
             .help("Specify the number of shm files to be created"),
         Arg::with_name("shm_numa_dir_pattern")
+            .long("pat")
             .short("p")
+            .required(false)
             .default_value("filecoin-proof-label/numa_$NUMA_NODE_INDEX")
             .help("Specify the shared memory directory pattern"),
     ]);
@@ -97,18 +104,23 @@ pub(crate) fn submatch(subargs: &ArgMatches<'_>) -> Result<()> {
     }
 }
 
-#[cfg(target_os = "Linux")]
+#[cfg(target_os = "linux")]
 fn shm_init(m: &ArgMatches) -> Result<()> {
     use clap::value_t;
 
-    let numa_node_idx = value_t!(m, "numa_node", u32).context("invalid NUMA node index")?;
+    let numa_node_idx = value_t!(m, "numa_node_index", u32).context("invalid NUMA node index")?;
     let size = value_t!(m, "size", bytesize::ByteSize).context("invalid file size")?;
     let num = value_t!(m, "number_of_files", usize).context("invalid number_of_files")?;
     let pat = value_t!(m, "shm_numa_dir_pattern", String)?;
-    shm::init_shm_files(numa_node_idx, size, num, pat)
+    let files = shm::init_shm_files(numa_node_idx, size, num, pat)?;
+    println!("Created SHM files:");
+    for file in files {
+        println!("{}", file.display())
+    }
+    Ok(())
 }
 
-#[cfg(not(target_os = "Linux"))]
+#[cfg(not(target_os = "linux"))]
 fn shm_init(_m: &ArgMatches) -> Result<()> {
     Err(anyhow!("This operation is only supported for the Linux operating system"))
 }

--- a/venus-worker/src/bin/venus-worker/store.rs
+++ b/venus-worker/src/bin/venus-worker/store.rs
@@ -122,5 +122,5 @@ fn shm_init(m: &ArgMatches) -> Result<()> {
 
 #[cfg(not(target_os = "linux"))]
 fn shm_init(_m: &ArgMatches) -> Result<()> {
-    Err(anyhow!("This operation is only supported for the Linux operating system"))
+    Err(anyhow!("This command is only supported for the Linux operating system"))
 }

--- a/venus-worker/src/bin/venus-worker/store.rs
+++ b/venus-worker/src/bin/venus-worker/store.rs
@@ -4,6 +4,9 @@ use tracing::{error, info};
 
 use venus_worker::{objstore::filestore::FileStore, store::Store};
 
+#[cfg(target_os = "Linux")]
+mod shm;
+
 pub const SUB_CMD_NAME: &str = "store";
 
 pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
@@ -25,10 +28,32 @@ pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
             .help("location of the store"),
     );
 
+    let shm_init_cmd = SubCommand::with_name("shm-init").args(&[
+        Arg::with_name("numa_node")
+            .long("node")
+            .takes_value(true)
+            .help("Specify the numa node"),
+        Arg::with_name("size")
+            .short("s")
+            .takes_value(true)
+            .possible_values(&["32Gib", "64Gib"])
+            .help("Specify the size of each shm file. (e.g., 1B, 2KB, 3kiB, 1MB, 2MiB, 3GB, 1GiB, ...)"),
+        Arg::with_name("number_of_files")
+            .long("num")
+            .short("n")
+            .takes_value(true)
+            .help("Specify the number of shm files to be created"),
+        Arg::with_name("shm_numa_dir_pattern")
+            .short("p")
+            .default_value("filecoin-proof-label/numa_$NUMA_NODE_INDEX")
+            .help("Specify the shared memory directory pattern"),
+    ]);
+
     SubCommand::with_name(SUB_CMD_NAME)
         .setting(AppSettings::ArgRequiredElseHelp)
         .subcommand(store_init_cmd)
         .subcommand(filestore_init_cmd)
+        .subcommand(shm_init_cmd)
 }
 
 pub(crate) fn submatch(subargs: &ArgMatches<'_>) -> Result<()> {
@@ -66,7 +91,24 @@ pub(crate) fn submatch(subargs: &ArgMatches<'_>) -> Result<()> {
 
             Ok(())
         }
+        ("shm-init", Some(m)) => shm_init(m),
 
         (other, _) => Err(anyhow!("unexpected subcommand `{}` of store", other)),
     }
+}
+
+#[cfg(target_os = "Linux")]
+fn shm_init(m: &ArgMatches) -> Result<()> {
+    use clap::value_t;
+
+    let numa_node_idx = value_t!(m, "numa_node", u32).context("invalid NUMA node index")?;
+    let size = value_t!(m, "size", bytesize::ByteSize).context("invalid file size")?;
+    let num = value_t!(m, "number_of_files", usize).context("invalid number_of_files")?;
+    let pat = value_t!(m, "shm_numa_dir_pattern", String)?;
+    shm::init_shm_files(numa_node_idx, size, num, pat)
+}
+
+#[cfg(not(target_os = "Linux"))]
+fn shm_init(_m: &ArgMatches) -> Result<()> {
+    Err(anyhow!("This operation is only supported for the Linux operating system"))
 }

--- a/venus-worker/src/bin/venus-worker/store.rs
+++ b/venus-worker/src/bin/venus-worker/store.rs
@@ -40,7 +40,6 @@ pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
             .short("s")
             .required(true)
             .takes_value(true)
-            .possible_values(&["32GiB", "64GiB"])
             .help("Specify the size of each shm file. (e.g., 1B, 2KB, 3kiB, 1MB, 2MiB, 3GB, 1GiB, ...)"),
         Arg::with_name("number_of_files")
             .long("num")

--- a/venus-worker/src/bin/venus-worker/store.rs
+++ b/venus-worker/src/bin/venus-worker/store.rs
@@ -52,7 +52,7 @@ pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
             .long("pat")
             .short("p")
             .required(false)
-            .default_value("filecoin-proof-label/numa_$NUMA_NODE_INDEX")
+            .default_value(default_shm_numa_dir_pattern())
             .help("Specify the shared memory directory pattern"),
     ]);
 
@@ -123,4 +123,17 @@ fn shm_init(m: &ArgMatches) -> Result<()> {
 #[cfg(not(target_os = "linux"))]
 fn shm_init(_m: &ArgMatches) -> Result<()> {
     Err(anyhow!("This command is only supported for the Linux operating system"))
+}
+
+fn default_shm_numa_dir_pattern() -> &'static str {
+    use std::sync::Once;
+
+    use vc_processors::fil_proofs::settings::ShmNumaDirPattern;
+
+    static mut PAT: String = String::new();
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| unsafe { PAT = format!("filecoin-proof-label/numa_{}", ShmNumaDirPattern::NUMA_NODE_IDX_VAR_NAME) });
+
+    unsafe { PAT.as_str() }
 }

--- a/venus-worker/src/bin/venus-worker/store/shm.rs
+++ b/venus-worker/src/bin/venus-worker/store/shm.rs
@@ -72,7 +72,7 @@ impl<'a> Drop for ShmFile<'a> {
 fn allocate_file(file: &File, size: u64) -> io::Result<()> {
     use std::os::unix::io::AsRawFd;
 
-    file.set_len(size)?;
+    // file.set_len(size)?;
 
     let fd = file.as_raw_fd();
     let size: libc::off_t = size.try_into().unwrap();
@@ -90,7 +90,7 @@ fn handle_enospc(s: &str) -> io::Result<()> {
     let errno = err.raw_os_error().unwrap_or(0);
     debug!("allocate_file: {} failed errno={}", s, errno);
     if errno == libc::ENOSPC {
-        return Err(err.into());
+        return Err(err);
     }
     Ok(())
 }

--- a/venus-worker/src/bin/venus-worker/store/shm.rs
+++ b/venus-worker/src/bin/venus-worker/store/shm.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use bytesize::ByteSize;
 use time::OffsetDateTime;
 use tracing::{debug, warn};
@@ -12,9 +12,9 @@ use vc_processors::sys::numa::Numa;
 
 pub fn init_shm_files(numa_node_idx: u32, size: ByteSize, num: usize, shm_numa_dir_pattern: String) -> Result<Vec<PathBuf>> {
     // bind NUMA node
-    let numa = Numa::new().context("NUMA not available")?;
+    let numa = Numa::new().map_err(|_| anyhow!("NUMA not available"))?;
     numa.bind(numa_node_idx)
-        .with_context(|| format!("invalid NUMA node: {}", numa_node_idx));
+        .map_err(|_| anyhow!("invalid NUMA node: {}", numa_node_idx))?;
 
     let mut dir = PathBuf::from("/dev/shm");
     dir.push(

--- a/venus-worker/src/bin/venus-worker/store/shm.rs
+++ b/venus-worker/src/bin/venus-worker/store/shm.rs
@@ -25,7 +25,7 @@ pub fn init_shm_files(numa_node_idx: u32, size: ByteSize, num: usize, shm_numa_d
 
     let filename = size.to_string_as(true).replace(' ', "_");
 
-    let paths = (0..num).map(|i| dir.join(format!("{}_{}", filename, now, i))).collect::<Vec<_>>();
+    let paths = (0..num).map(|i| dir.join(format!("{}_{}", filename, i))).collect::<Vec<_>>();
 
     let files = paths
         .iter()

--- a/venus-worker/src/bin/venus-worker/store/shm.rs
+++ b/venus-worker/src/bin/venus-worker/store/shm.rs
@@ -1,0 +1,89 @@
+use std::{
+    fs::{remove_file, File, OpenOptions},
+    io, mem,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use bytesize::ByteSize;
+use time::OffsetDateTime;
+use tracing::{debug, warn};
+
+pub fn init_shm_files(numa_node_idx: u32, size: ByteSize, num: usize, shm_numa_dir_pattern: String) -> Result<Vec> {
+    let mut dir = PathBuf::from("/dev/shm");
+    dir.push(
+        shm_numa_dir_pattern
+            .trim_matches('/')
+            .replacen("$NUMA_NODE_INDEX", &numa_node_idx.to_string(), 1),
+    );
+
+    let filename = size.to_string_as(true).replace(' ', "_");
+
+    let now = OffsetDateTime::now_local()
+        .unwrap_or_else(|_| OffsetDateTime::now_utc())
+        .unix_timestamp();
+
+    let paths = (0..num)
+        .map(|i| dir.join(format!("{}_{}_{}", filename, now, i)))
+        .collect::<Vec<_>>();
+
+    let files = paths
+        .iter()
+        .map(|p| {
+            let file = ShmFile(p);
+            file.create_and_allocate(size.as_u64())?;
+            Ok(file)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    // All files are created successfully, which means the initialization of
+    // the shared memory files is successful, avoid destroying any file
+    files.into_iter().for_each(mem::forget);
+    Ok(paths)
+}
+
+struct ShmFile<'a>(&'a Path);
+
+impl<'a> ShmFile<'a> {
+    fn create_and_allocate(&self, size: u64) -> Result<()> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(self.0)
+            .context("create new shm file")?;
+        allocate_file(&file, size).context("allocate file")
+    }
+}
+
+impl<'a> Drop for ShmFile<'a> {
+    fn drop(&mut self) {
+        if let Err(e) = remove_file(self.0) {
+            warn!(err=?e, "Unable to destroy file: '{}'", self.0.display());
+        }
+    }
+}
+
+fn allocate_file(file: &File, size: u64) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    file.set_len(size)?;
+
+    let fd = file.as_raw_fd();
+    let size: libc::off_t = size.try_into().unwrap();
+
+    if unsafe { libc::fallocate(fd, 0, 0, size) } == 0 {
+        return Ok(());
+    }
+    handle_enospc("fallocate()")?;
+
+    Ok(())
+}
+
+fn handle_enospc(s: &str) -> io::Result<()> {
+    let err = io::Error::last_os_error();
+    let errno = err.raw_os_error().unwrap_or(0);
+    debug!("allocate_file: {} failed errno={}", s, errno);
+    if errno == libc::ENOSPC {
+        return Err(err.into());
+    }
+    Ok(())
+}

--- a/venus-worker/vc-processors/Cargo.toml
+++ b/venus-worker/vc-processors/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { version = "1.1", features = ["v4", "fast-rng"] }
 forest_address = { version = "0.3", optional = true }
 base64-serde = { version = "0.6", optional = true }
 base64 = { version = "0.13", optional = true }
+lazy_static = "1.4"
 
 [dependencies.filecoin-proofs]
 version = "11.1"

--- a/venus-worker/vc-processors/Cargo.toml
+++ b/venus-worker/vc-processors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vc-processors"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 keywords = [

--- a/venus-worker/vc-processors/src/fil_proofs/mod.rs
+++ b/venus-worker/vc-processors/src/fil_proofs/mod.rs
@@ -33,6 +33,8 @@ pub use filecoin_proofs_api::{
     RegisteredSealProof, RegisteredUpdateProof, SectorId, Ticket, UnpaddedBytesAmount,
 };
 
+pub use storage_proofs_core::settings;
+
 /// Identifier for Actors.
 pub type ActorID = u64;
 

--- a/venus-worker/vc-processors/src/lib.rs
+++ b/venus-worker/vc-processors/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 
 pub mod core;
-pub(crate) mod sys;
+pub mod sys;
 
 #[cfg(feature = "fil-proofs")]
 #[allow(missing_docs)]

--- a/venus-worker/vc-processors/src/sys/mod.rs
+++ b/venus-worker/vc-processors/src/sys/mod.rs
@@ -1,2 +1,5 @@
+//! This module provides some operating system level APIs or bindings of native libraries
+//!
+
 #[cfg(feature = "numa")]
 pub mod numa;

--- a/venus-worker/vc-processors/src/sys/numa.rs
+++ b/venus-worker/vc-processors/src/sys/numa.rs
@@ -72,6 +72,7 @@ impl Numa {
 
     /// Binds the current task and its children to the specified NUMA node
     /// They will only run on the CPUs of the specified nodes and only be able to allocate memory from them.
+    /// Return max size of the nodemask of Err if `node` greater than the size of the nodemask.
     pub fn bind(&self, node: u32) -> Result<(), u64> {
         bind(node)
     }

--- a/venus-worker/vc-processors/src/sys/numa.rs
+++ b/venus-worker/vc-processors/src/sys/numa.rs
@@ -1,22 +1,141 @@
 use std::env::var;
-use std::os::raw::c_int;
+use std::os::raw::{c_int, c_uint, c_ulong};
 
+use lazy_static::lazy_static;
 use tracing::{info, warn};
 
 /// env key for preferred numa node
 pub const ENV_NUMA_PREFERRED: &str = "VENUS_WORKER_NUMA_PREFERRED";
 
+lazy_static! {
+    static ref NUMA_AVAILABLE: bool = unsafe { numa_available() >= 0 };
+}
+
 #[link(name = "numa", kind = "dylib")]
 extern "C" {
+    /// Check if NUMA support is enabled. Returns -1 if not enabled, in which case other functions will undefined
     fn numa_available() -> c_int;
     fn numa_set_preferred(node: c_int);
     fn numa_max_node() -> c_int;
+
+    /// returns a bitmask of a size equal to the kernel's node mask (kernel type nodemask_t).
+    /// In other words, large enough to represent MAX_NUMNODES nodes.
+    fn numa_allocate_nodemask() -> *mut NumaBitmask;
+
+    /// Returns a bitmask of a size equal to the kernel's cpu mask (kernel type cpumask_t).
+    /// In other words, large enough to represent NR_CPUS cpus.
+    fn numa_allocate_cpumask() -> *mut NumaBitmask;
+
+    /// Deallocates the memory of both the bitmask structure pointed to by bmp and the bit mask.
+    /// It is an error to attempt to free this bitmask twice.
+    fn numa_bitmask_free(bmp: *mut NumaBitmask);
+
+    /// Sets a specified bit in a bit mask to 1.
+    /// Nothing is done if n is greater than the size of the bitmask (and no error is returned).
+    /// The value of bmp is always returned.
+    fn numa_bitmask_setbit(bmp: *mut NumaBitmask, n: c_uint) -> *mut NumaBitmask;
+
+    /// Binds the current task and its children to the nodes specified in nodemask.
+    /// They will only run on the CPUs of the specified nodes and only be able to allocate memory from them.
+    fn numa_bind(nodemask: *mut NumaBitmask);
+}
+
+pub struct Numa;
+
+enum Error {
+    NumaNotAvailable,
+    OutOfBounds,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Numa {
+    pub fn new() -> Result<Self> {
+        if *NUMA_AVAILABLE {
+            Ok(Self)
+        } else {
+            Err(Error::NumaNotAvailable)
+        }
+    }
+
+    pub fn alloc_nodemask() -> Bitmask {
+        Bitmask::alloc_nodemask()
+    }
+
+    pub fn alloc_cpumask() -> Bitmask {
+        Bitmask::alloc_cpumask()
+    }
+
+    pub fn bind(&self, node: u32) {
+        bind(node);
+    }
+
+    pub fn bind_with_nodemask(nodemask: &mut Bitmask) {
+        bind_with_nodemask(nodemask)
+    }
+}
+
+#[repr(C)]
+struct NumaBitmask {
+    /// number of bits in the map
+    size: c_ulong,
+    maskp: *mut c_ulong,
+}
+
+pub struct Bitmask {
+    inner: *mut NumaBitmask,
+}
+
+impl Bitmask {
+    fn alloc_nodemask() -> Self {
+        Self {
+            inner: unsafe { numa_allocate_nodemask() },
+        }
+    }
+
+    fn alloc_cpumask() -> Self {
+        Self {
+            inner: unsafe { numa_allocate_cpumask() },
+        }
+    }
+
+    pub fn set_bit(&mut self, bit: u32) {
+        unsafe {
+            numa_bitmask_setbit(self.inner, bit as c_uint);
+        }
+    }
+
+    pub fn size(&self) -> u64 {
+        unsafe { (*self.inner).size as u64 }
+    }
+}
+
+impl Drop for Bitmask {
+    fn drop(&mut self) {
+        unsafe { numa_bitmask_free(self.inner) }
+    }
+}
+
+fn bind(node: u32) -> Result<()> {
+    let mut nodemask = Bitmask::alloc_nodemask();
+    if node >= nodemask.size() {
+        return Err(Error::OutOfBounds);
+    }
+    nodemask.set_bit(node);
+    bind_with_nodemask(&mut nodemask);
+    Ok(())
+}
+
+fn bind_with_nodemask(nodemask: &mut Bitmask) {
+    unsafe {
+        numa_bind(nodemask);
+    }
 }
 
 /// set numa policy to preferred for current process
 pub fn set_preferred(node: c_int) {
     unsafe {
-        if numa_available() < 0 {
+        if !*NUMA_AVAILABLE {
             warn!("numa is not available");
             return;
         }


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

resolve #85 

related PR: ipfs-force-community/rust-fil-proofs#1, ipfs-force-community/rust-fil-proofs#2

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
1. 将 rust-fil-proofs 相关依赖替换为 [ipfs-force-community/rust-fil-proofs](https://github.com/ipfs-force-community/rust-fil-proofs/tree/force/master_v11.1.1) 该分支支持使用共享内存
2. 新增 NUMA 函数绑定
3. worker 新增 `./worker store shm-init` 子命令用于创建共享内存文件

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 具有清晰明确的 commit message / All commits have a clear commit message.
- [ ] 包含必要的测试用例 / This PR has tests for new functionality or change in behaviour
- [x] 包含必要的指南或文档 / If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included
- [x] 通过必要的检查项 / All checks are green
