### PR TITLE
fix(hwinfo): upgrade hwloc2 lib to solve the null pointer

### DIFF
--- a/venus-worker-util/Cargo.lock
+++ b/venus-worker-util/Cargo.lock
@@ -408,7 +408,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hwloc2"
 version = "2.2.0"
-source = "git+https://github.com/ipfs-force-community/hwloc2-rs.git?branch=force_main#81106ef7ebb65a4d7f3e24bfb34fa7c1469679c6"
+source = "git+https://github.com/ipfs-force-community/hwloc2-rs.git?branch=force_main#93167d3b8add176cd2b8a81797c8f4680ef9d472"
 dependencies = [
  "bitflags",
  "errno",

--- a/venus-worker-util/Makefile
+++ b/venus-worker-util/Makefile
@@ -1,3 +1,5 @@
+export GIT_COMMIT=git.$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))
+
 all: fmt clippy build-all
 
 test-all:


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

fix #341

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
升级 hwloc2 解决获取 NUMANode 时可能的空指针问题。
hwloc2 改动: https://github.com/ipfs-force-community/hwloc2-rs/commit/93167d3b8add176cd2b8a81797c8f4680ef9d472

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 具有清晰明确的 commit message / All commits have a clear commit message.
- [ ] 包含必要的测试用例 / This PR has tests for new functionality or change in behaviour
- [ ] 包含必要的指南或文档 / If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included
- [x] 通过必要的检查项 / All checks are green
