### PR TITLE
feat(vsmgr:mertics): import metrics & add some view

### DIFF
--- a/docs/zh/14.venus-sector-manager的mertics使用.md
+++ b/docs/zh/14.venus-sector-manager的mertics使用.md
@@ -1,0 +1,34 @@
+# venus-sector-manager的metrics使用
+venus-cluster使用metrics来记录程序运行过程中的性能指标，本篇主要讲venus-sector-manager中metrics的意义，关于如何使用metrics进行进程的监控，
+可以找到很多资料，不在此进行赘述。
+
+## exporter info
+venus-sector-manager的exporter和rpc使用同样的端口，url为`/metrics`, 因此对于默认的部署方式，exporter的url为
+`host:1789/metrics`
+
+## metrics type
+
+####  VenusClusterInfo
+sector manager启动的时候会将这个标记置成1。
+
+#### SectorManagerNewSector
+sector manager记录新建扇区的计数器，存在miner的tag，根据不同的miner分开统计。
+
+#### SectorManagerPreCommitSector
+sector manager记录扇区preCommit次数的计数器，存在miner的tag，根据不同的miner分开统计。
+
+#### SectorManagerCommitSector
+sector manager记录扇区commit次数的计数器，存在miner的tag，根据不同的miner分开统计。
+
+#### ProverWinningPostDuration
+prover侧记录winningPost时间跨度的计数器，存在miner的tag，根据不同的miner分开统计，并且计算时间会按s作单位，进行分段统计。**目前还没有启用**。
+
+#### ProverWindowPostDuration
+prover侧记录windowPost时间跨度的计数器，存在miner的tag，根据不同的miner分开统计,并且计算时间会按minute作单位，进行分段统计。**目前还没有启用**。
+
+#### ProverWindowPostCompleteRate
+prover侧记录windowPost完成率的计数器，在miner进入当前deadline倒数20个epoch的时候会开始显示partition的完成率，在没有进入倒计时状态的时候都显示1，
+进入之后显示完成率的小数，比如10个partition里有9个完成提交了，那么显示为0.9。存在miner的tag，根据不同的miner分开统计。**目前还没有启用**。
+
+#### APIRequestDuration
+sector manager的API都会记录其响应的时间，并且响应时间会按ms作单位，进行分段统计。

--- a/venus-sector-manager/go.mod
+++ b/venus-sector-manager/go.mod
@@ -49,11 +49,14 @@ require (
 	github.com/ipfs-force-community/venus-objstore v0.0.3
 )
 
-require github.com/filecoin-project/specs-actors/v8 v8.0.1
+require (
+	contrib.go.opencensus.io/exporter/prometheus v0.4.0
+	github.com/filecoin-project/specs-actors/v8 v8.0.1
+	go.opencensus.io v0.23.0
+)
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1 // indirect
-	contrib.go.opencensus.io/exporter/prometheus v0.4.0 // indirect
 	github.com/DataDog/zstd v1.4.1 // indirect
 	github.com/GeertJohan/go.incremental v1.0.0 // indirect
 	github.com/GeertJohan/go.rice v1.0.2 // indirect
@@ -219,7 +222,6 @@ require (
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel v1.3.0 // indirect
 	go.opentelemetry.io/otel/trace v1.3.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/venus-sector-manager/metrics/exporter.go
+++ b/venus-sector-manager/metrics/exporter.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+
+	"contrib.go.opencensus.io/exporter/prometheus"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+
+	"github.com/ipfs-force-community/venus-cluster/venus-sector-manager/pkg/logging"
+)
+
+const logMetrics = "metrics"
+
+var log = logging.New(logMetrics)
+
+func Exporter() http.Handler {
+	exporter, err := prometheus.NewExporter(prometheus.Options{
+		Namespace: "venus_sector_manager",
+	})
+	if err != nil {
+		log.Errorf("could not create the prometheus stats exporter: %v", err)
+	}
+
+	if err := view.Register(VenusClusterViews...); err != nil {
+		panic(err)
+	}
+
+	stats.Record(context.Background(), VenusClusterInfo.M(int64(1)))
+	return exporter
+}

--- a/venus-sector-manager/metrics/metrics.go
+++ b/venus-sector-manager/metrics/metrics.go
@@ -1,0 +1,129 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 3000, 4000, 5000, 7500, 10000, 20000, 50000, 100000)
+var winningPostSecondsDistribution = view.Distribution(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 100)
+var windowPostMinutesDistribution = view.Distribution(1, 5, 10, 15, 20, 25, 30)
+
+var (
+	Endpoint, _     = tag.NewKey("endpoint")
+	APIInterface, _ = tag.NewKey("api") // to distinguish between gateway api and full node api endpoint calls
+	Miner, _        = tag.NewKey("miner")
+)
+
+var (
+	// common
+	VenusClusterInfo = stats.Int64("info", "Arbitrary counter to tag venus cluster info", stats.UnitDimensionless)
+
+	SectorManagerNewSector = stats.Int64("sector_manager/new_sector", "Count the new sector", stats.UnitDimensionless)
+
+	SectorManagerPreCommitSector = stats.Int64("sector_manager/pre_commit_sector", "Count the pre commit sector", stats.UnitDimensionless)
+
+	SectorManagerCommitSector = stats.Int64("sector_manager/commit_sector", "Count the commit sector", stats.UnitDimensionless)
+
+	ProverWinningPostDuration = stats.Float64("prover/winning_post_duration", "Duration of winning post ", stats.UnitDimensionless)
+
+	ProverWindowPostDuration = stats.Float64("prover/window_post_duration", "Duration of window post", stats.UnitDimensionless)
+
+	ProverWindowPostCompleteRate = stats.Float64("prover/window_post_complete_rate", "Complete rate of window post", stats.UnitDimensionless)
+
+	APIRequestDuration = stats.Float64("api/request_duration_ms", "Duration of API requests", stats.UnitMilliseconds)
+)
+
+var (
+	InfoView = &view.View{
+		Name:        "info",
+		Description: "venus cluster information",
+		Measure:     VenusClusterInfo,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{},
+	}
+
+	NewSectorView = &view.View{
+		Name:        "new_sector",
+		Description: "count of sector manager new sector",
+		TagKeys:     []tag.Key{Miner},
+		Measure:     SectorManagerNewSector,
+		Aggregation: view.Count(),
+	}
+
+	SectorPreCommitView = &view.View{
+		Name:        "sector_pre_commit",
+		Description: "count of sector manager pre commit sector",
+		TagKeys:     []tag.Key{Miner},
+		Measure:     SectorManagerPreCommitSector,
+		Aggregation: view.Count(),
+	}
+
+	SectorCommitView = &view.View{
+		Name:        "sector_commit",
+		Description: "count of sector manager commit sector",
+		TagKeys:     []tag.Key{Miner},
+		Measure:     SectorManagerCommitSector,
+		Aggregation: view.Count(),
+	}
+
+	ProverWinningPostDurationView = &view.View{
+		TagKeys:     []tag.Key{Miner},
+		Measure:     ProverWinningPostDuration,
+		Aggregation: winningPostSecondsDistribution,
+	}
+
+	ProverWindowPostDurationView = &view.View{
+		TagKeys:     []tag.Key{Miner},
+		Measure:     ProverWindowPostDuration,
+		Aggregation: windowPostMinutesDistribution,
+	}
+
+	ProverWindowPostCompleteRateView = &view.View{
+		TagKeys:     []tag.Key{Miner},
+		Measure:     ProverWindowPostCompleteRate,
+		Aggregation: view.LastValue(),
+	}
+
+	APIRequestDurationView = &view.View{
+		Measure:     APIRequestDuration,
+		Aggregation: defaultMillisecondsDistribution,
+		TagKeys:     []tag.Key{APIInterface, Endpoint},
+	}
+)
+
+var VenusClusterViews = []*view.View{
+	InfoView,
+	NewSectorView,
+	APIRequestDurationView,
+	SectorPreCommitView,
+	SectorCommitView,
+	ProverWinningPostDurationView,
+	ProverWindowPostDurationView,
+	ProverWindowPostCompleteRateView,
+}
+
+type TimeParser func(time.Time) float64
+
+func Timer(ctx context.Context, m *stats.Float64Measure, fn TimeParser) func() {
+	start := time.Now()
+	return func() {
+		stats.Record(ctx, m.M(fn(start)))
+	}
+}
+
+func SinceInMilliseconds(startTime time.Time) float64 {
+	return float64(time.Since(startTime).Nanoseconds()) / 1e6
+}
+
+func SinceInSeconds(startTime time.Time) float64 {
+	return float64(time.Since(startTime).Nanoseconds()) / 1e9
+}
+
+func SinceInMinutes(startTime time.Time) float64 {
+	return float64(time.Since(startTime).Nanoseconds()) / 1e9 / 60
+}

--- a/venus-sector-manager/metrics/proxy/proxy.go
+++ b/venus-sector-manager/metrics/proxy/proxy.go
@@ -1,0 +1,50 @@
+package proxy
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/ipfs-force-community/venus-cluster/venus-sector-manager/metrics"
+)
+
+func MetricedSealerAPI(a interface{}) interface{} {
+	return proxy(a)
+}
+
+func proxy(in interface{}) interface{} {
+	fields := []reflect.StructField{}
+
+	valueIn := reflect.ValueOf(in)
+
+	for i := 0; i < valueIn.NumMethod(); i++ {
+		fields = append(fields, reflect.StructField{Name: valueIn.Type().Method(i).Name, Type: valueIn.Method(i).Type()})
+	}
+
+	internal := reflect.StructOf(fields)
+	internalValue := reflect.New(internal).Elem()
+	for i := 0; i < valueIn.NumMethod(); i++ {
+		fn := valueIn.Method(i)
+		funcName := valueIn.Type().Method(i).Name
+		internalValue.Field(i).Set(reflect.MakeFunc(valueIn.Method(i).Type(), func(args []reflect.Value) (results []reflect.Value) {
+			ctx := args[0].Interface().(context.Context)
+			// upsert function name into context
+			ctx, _ = metrics.New(ctx, metrics.Upsert(metrics.Endpoint, funcName))
+			stop := metrics.Timer(ctx, metrics.APIRequestDuration, metrics.SinceInMilliseconds)
+			defer stop()
+			// pass tagged ctx back into function call
+			args[0] = reflect.ValueOf(ctx)
+			return fn.Call(args)
+		}))
+	}
+
+	outStruct := reflect.StructOf([]reflect.StructField{reflect.StructField{
+		Name: "Internal",
+		Type: reflect.TypeOf(internalValue.Addr().Interface()).Elem(),
+	}})
+
+	outValue := reflect.New(outStruct).Elem()
+
+	outValue.Field(0).Set(internalValue)
+
+	return outValue.Addr().Interface()
+}

--- a/venus-sector-manager/metrics/re_export.go
+++ b/venus-sector-manager/metrics/re_export.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+var (
+	NewKey = tag.NewKey
+	New    = tag.New
+	Upsert = tag.Upsert
+
+	Record = stats.Record
+)
+
+type Key = tag.Key


### PR DESCRIPTION
## 关联的Issues (Related Issues)
resolve #339 
resolve #340 

## 改动 (Proposed Changes)
venus-cluster中vsmgr部分引入mertics框架：
1. 在rpc端口上加入`/mertics`用于export mertics
2. vcs接口级别的时间mertics
3. 对于扇区的流程在关键处（新建，precommit，provecommit）加入计数
4. prover侧对于proof的产生时间的mertics
5. 当前服务的miner在当前deadline结束前20个高度会产生windowpost的完成率

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 具有清晰明确的 commit message / All commits have a clear commit message.
- [ ] 包含必要的测试用例 / This PR has tests for new functionality or change in behaviour
- [x] 包含必要的指南或文档 / If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included
- [x] 通过必要的检查项 / All checks are green
