### PR TITLE
Feat/0x5459/task can be idle

### DIFF
--- a/docs/en/03.venus-worker-config.md
+++ b/docs/en/03.venus-worker-config.md
@@ -236,7 +236,7 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 # default is null
 # min_deal_space = "8GiB"
 
-# Number of retries when an error of `temp` type is encountered during the sealing process , optional items, number format
+# Number of retries when an error of `temp` type is encountered during the sealing process, optional items, number format
 # default is 5
 # max_retries = 3
 
@@ -258,6 +258,10 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 # Default is false
 # Usually only set this during testing
 # ignore_proof_check = false
+
+# Number of retries when unable to get a task from `sector_manager`, optional items, number format
+# default is 3
+# allocate_max_retries = 3
 ````
 
 The configuration items in `sealing` usually have default items preset from experiences, which removes the need for manual configurations in most cases.
@@ -317,6 +321,7 @@ location = "/mnt/nvme1/store"
 # sealing.recover_interval = "60s"
 # sealing.rpc_polling_interval = "180s"
 # sealing.ignore_proof_check = false
+# sealing.allocate_max_retries = 3
 
 [[sealing_thread]]
 location = "/mnt/nvme2/store"

--- a/docs/en/03.venus-worker-config.md
+++ b/docs/en/03.venus-worker-config.md
@@ -189,11 +189,11 @@ And in other scenarios, you would need to manually configure the options here as
 # Normally, use the `multiaddr` format for consistency with other components
 rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 
-# The http header information when constructing the rpc client, optional items, dictionary type
+# The http header information when constructing the rpc client, optional, dictionary type
 # default is null
 # rpc_client.headers = { User-Agent = "jsonrpc-core-client" }
 
-# The verification token carried when requesting deal piece data, optional items, string type
+# The verification token carried when requesting deal piece data, optional, string type
 # default is null
 # This is usually set when this instance allows sealing of sectors with deal data
 # The value of this config item is usually the token value of the Venus service used
@@ -236,11 +236,11 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 # default is null
 # min_deal_space = "8GiB"
 
-# Number of retries when an error of `temp` type is encountered during the sealing process, optional items, number format
+# Number of retries when an error of `temp` type is encountered during the sealing process, optional, number format
 # default is 5
 # max_retries = 3
 
-# Retry interval when a `temp` type error is encountered during the sealing process, optional items, time string format
+# Retry interval when a `temp` type error is encountered during the sealing process, optional, time string format
 # The default is "30s", which means 30 seconds
 # recover_interval = "30s"
 
@@ -259,7 +259,7 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 # Usually only set this during testing
 # ignore_proof_check = false
 
-# Number of retries when unable to get a task from `sector_manager`, optional items, number format
+# Number of retries when unable to get a task from `sector_manager`, optional, number format
 # default is 3
 # allocate_max_retries = 3
 ````

--- a/docs/en/03.venus-worker-config.md
+++ b/docs/en/03.venus-worker-config.md
@@ -259,9 +259,9 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 # Usually only set this during testing
 # ignore_proof_check = false
 
-# Number of retries when unable to get a task from `sector_manager`, optional, number format
+# Number of retries when unable to request a task from `sector_manager`, optional, number format
 # default is 3
-# allocate_max_retries = 3
+# request_task_max_retries = 3
 ````
 
 The configuration items in `sealing` usually have default items preset from experiences, which removes the need for manual configurations in most cases.
@@ -321,7 +321,7 @@ location = "/mnt/nvme1/store"
 # sealing.recover_interval = "60s"
 # sealing.rpc_polling_interval = "180s"
 # sealing.ignore_proof_check = false
-# sealing.allocate_max_retries = 3
+# sealing.request_task_max_retries = 3
 
 [[sealing_thread]]
 location = "/mnt/nvme2/store"

--- a/docs/zh/03.venus-worker的配置解析.md
+++ b/docs/zh/03.venus-worker的配置解析.md
@@ -261,6 +261,10 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 # 默认为 false
 # 通常只在诸如测试之类的情况下设置此项
 # ignore_proof_check = false
+
+# 无法从 `sector_manager` 获取任务时，重试的次数，选填项，数字类型
+# 默认为 3
+# allocate_max_retries = 3
 ```
 
 `sealing` 中的配置项通常有根据经验预设的默认项，这使得我们在绝大多数情况下无需自行配置。
@@ -329,6 +333,7 @@ location = "/mnt/nvme1/store"
 # sealing.recover_interval = "60s"
 # sealing.rpc_polling_interval = "180s"
 # sealing.ignore_proof_check = false
+# sealing.allocate_max_retries = 3
 
 [[sealing_thread]]
 location = "/mnt/nvme2/store"
@@ -411,6 +416,7 @@ venus-worker 中的 `sealing_thread` 会在新的扇区任务开始之前检查 
 # sealing.recover_interval = "60s"
 # sealing.rpc_polling_interval = "180s"
 # sealing.ignore_proof_check = false
+# sealing.allocate_max_retries = 3
 ```
 
 

--- a/docs/zh/03.venus-worker的配置解析.md
+++ b/docs/zh/03.venus-worker的配置解析.md
@@ -264,7 +264,7 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 
 # 无法从 `sector_manager` 获取任务时，重试的次数，选填项，数字类型
 # 默认为 3
-# allocate_max_retries = 3
+# request_task_max_retries = 3
 ```
 
 `sealing` 中的配置项通常有根据经验预设的默认项，这使得我们在绝大多数情况下无需自行配置。
@@ -333,7 +333,7 @@ location = "/mnt/nvme1/store"
 # sealing.recover_interval = "60s"
 # sealing.rpc_polling_interval = "180s"
 # sealing.ignore_proof_check = false
-# sealing.allocate_max_retries = 3
+# sealing.request_task_max_retries = 3
 
 [[sealing_thread]]
 location = "/mnt/nvme2/store"
@@ -416,7 +416,7 @@ venus-worker 中的 `sealing_thread` 会在新的扇区任务开始之前检查 
 # sealing.recover_interval = "60s"
 # sealing.rpc_polling_interval = "180s"
 # sealing.ignore_proof_check = false
-# sealing.allocate_max_retries = 3
+# sealing.request_task_max_retries = 3
 ```
 
 

--- a/venus-worker/src/config.rs
+++ b/venus-worker/src/config.rs
@@ -55,8 +55,8 @@ pub struct Sealing {
     /// ignore proof state check
     pub ignore_proof_check: bool,
 
-    /// max retry times for allocate task from sector manager
-    pub allocate_max_retries: u32,
+    /// max retry times for request task from sector manager
+    pub request_task_max_retries: u32,
 }
 
 impl Default for Sealing {
@@ -73,7 +73,7 @@ impl Default for Sealing {
             recover_interval: Duration::from_secs(60),
             rpc_polling_interval: Duration::from_secs(180),
             ignore_proof_check: false,
-            allocate_max_retries: 3,
+            request_task_max_retries: 3,
         }
     }
 }
@@ -120,8 +120,8 @@ pub struct SealingOptional {
     /// ignore proof state check
     pub ignore_proof_check: Option<bool>,
 
-    /// max retry times for allocate task from sector manager
-    pub allocate_max_retries: Option<u32>,
+    /// max retry times for request task from sector manager
+    pub request_task_max_retries: Option<u32>,
 }
 
 /// configuration for remote store

--- a/venus-worker/src/config.rs
+++ b/venus-worker/src/config.rs
@@ -54,6 +54,9 @@ pub struct Sealing {
 
     /// ignore proof state check
     pub ignore_proof_check: bool,
+
+    /// max retry times for allocate task from sector manager
+    pub allocate_max_retries: u32,
 }
 
 impl Default for Sealing {
@@ -70,6 +73,7 @@ impl Default for Sealing {
             recover_interval: Duration::from_secs(60),
             rpc_polling_interval: Duration::from_secs(180),
             ignore_proof_check: false,
+            allocate_max_retries: 3,
         }
     }
 }
@@ -115,6 +119,9 @@ pub struct SealingOptional {
 
     /// ignore proof state check
     pub ignore_proof_check: Option<bool>,
+
+    /// max retry times for allocate task from sector manager
+    pub allocate_max_retries: Option<u32>,
 }
 
 /// configuration for remote store

--- a/venus-worker/src/sealing/store/mod.rs
+++ b/venus-worker/src/sealing/store/mod.rs
@@ -241,6 +241,7 @@ fn merge_sealing_fields(default_sealing: Sealing, mut customized: SealingOptiona
             recover_interval,
             rpc_polling_interval,
             ignore_proof_check,
+            allocate_max_retries,
         },
     }
 }
@@ -363,6 +364,7 @@ mod tests {
                         recover_interval: ms(1000),
                         rpc_polling_interval: ms(1000),
                         ignore_proof_check: true,
+                        allocate_max_retries: 10,
                     },
                 },
                 SealingThreadInner {
@@ -379,6 +381,7 @@ mod tests {
                         recover_interval: Some(ms(2000)),
                         rpc_polling_interval: Some(ms(1000)),
                         ignore_proof_check: None,
+                        allocate_max_retries: Some(11),
                     }),
                 },
                 SealingWithPlan {
@@ -395,6 +398,7 @@ mod tests {
                         recover_interval: ms(2000),
                         rpc_polling_interval: ms(1000),
                         ignore_proof_check: true,
+                        allocate_max_retries: 11,
                     },
                 },
             ),

--- a/venus-worker/src/sealing/store/mod.rs
+++ b/venus-worker/src/sealing/store/mod.rs
@@ -241,7 +241,7 @@ fn merge_sealing_fields(default_sealing: Sealing, mut customized: SealingOptiona
             recover_interval,
             rpc_polling_interval,
             ignore_proof_check,
-            allocate_max_retries,
+            request_task_max_retries,
         },
     }
 }
@@ -364,7 +364,7 @@ mod tests {
                         recover_interval: ms(1000),
                         rpc_polling_interval: ms(1000),
                         ignore_proof_check: true,
-                        allocate_max_retries: 10,
+                        request_task_max_retries: 10,
                     },
                 },
                 SealingThreadInner {
@@ -381,7 +381,7 @@ mod tests {
                         recover_interval: Some(ms(2000)),
                         rpc_polling_interval: Some(ms(1000)),
                         ignore_proof_check: None,
-                        allocate_max_retries: Some(11),
+                        request_task_max_retries: Some(11),
                     }),
                 },
                 SealingWithPlan {
@@ -398,7 +398,7 @@ mod tests {
                         recover_interval: ms(2000),
                         rpc_polling_interval: ms(1000),
                         ignore_proof_check: true,
-                        allocate_max_retries: 11,
+                        request_task_max_retries: 11,
                     },
                 },
             ),

--- a/venus-worker/src/sealing/worker/task/event.rs
+++ b/venus-worker/src/sealing/worker/task/event.rs
@@ -19,6 +19,9 @@ pub enum Event {
     // No specified tasks available from sector_manager.
     Idle,
 
+    // If `Planner::exec` returns `Event::Retry` it will be retried indefinitely
+    // until `Planner::exec` returns another `Event` or an error occurs
+    #[allow(dead_code)]
     Retry,
 
     Allocate(AllocatedSector),

--- a/venus-worker/src/sealing/worker/task/event.rs
+++ b/venus-worker/src/sealing/worker/task/event.rs
@@ -77,7 +77,7 @@ impl Debug for Event {
         let name = match self {
             Self::SetState(_) => "SetState",
 
-            Self::Idle => "idle",
+            Self::Idle => "Idle",
 
             Self::Retry => "Retry",
 

--- a/venus-worker/src/sealing/worker/task/event.rs
+++ b/venus-worker/src/sealing/worker/task/event.rs
@@ -16,7 +16,7 @@ use crate::sealing::processor::{
 pub enum Event {
     SetState(State),
 
-    // No tasks available from sector_manager.
+    // No specified tasks available from sector_manager.
     Idle,
 
     Retry,

--- a/venus-worker/src/sealing/worker/task/event.rs
+++ b/venus-worker/src/sealing/worker/task/event.rs
@@ -16,6 +16,9 @@ use crate::sealing::processor::{
 pub enum Event {
     SetState(State),
 
+    // No tasks available from sector_manager.
+    Idle,
+
     Retry,
 
     Allocate(AllocatedSector),
@@ -73,6 +76,8 @@ impl Debug for Event {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             Self::SetState(_) => "SetState",
+
+            Self::Idle => "idle",
 
             Self::Retry => "Retry",
 
@@ -166,6 +171,8 @@ impl Event {
     fn apply_changes(self, s: &mut Sector) {
         match self {
             Self::SetState(_) => {}
+
+            Self::Idle => {}
 
             Self::Retry => {}
 

--- a/venus-worker/src/sealing/worker/task/mod.rs
+++ b/venus-worker/src/sealing/worker/task/mod.rs
@@ -273,7 +273,12 @@ impl<'c> Task<'c> {
                     if let Event::Idle = evt {
                         task_idle_count += 1;
                         if task_idle_count > TASK_MAX_IDLE_TIMES {
-                            info!("The task has been idle for {} times. break the task", task_idle_count);
+                            info!("The task has been idle for more than {} times. break the task", TASK_MAX_IDLE_TIMES);
+
+                            // when trying to allocate a task but no task for more than `TASK_MAX_IDLE_TIMES` 
+                            // times, this task is really considered idle, break this task loop.
+                            // that we have a chance to reload `sealing_thread` hot config file,
+                            // or do something else.
                             self.finalize()?;
                             return Ok(());
                         }

--- a/venus-worker/src/sealing/worker/task/mod.rs
+++ b/venus-worker/src/sealing/worker/task/mod.rs
@@ -393,7 +393,7 @@ impl<'c> Task<'c> {
                     debug!(
                         prev = ?self.sector.state,
                         sleep = ?self.store.config.recover_interval,
-                        "{:?} captured", evt
+                        "Event::{:?} captured", evt
                     );
 
                     self.wait_or_interruptted(self.store.config.recover_interval)?;

--- a/venus-worker/src/sealing/worker/task/mod.rs
+++ b/venus-worker/src/sealing/worker/task/mod.rs
@@ -275,7 +275,7 @@ impl<'c> Task<'c> {
                         if task_idle_count > TASK_MAX_IDLE_TIMES {
                             info!("The task has been idle for more than {} times. break the task", TASK_MAX_IDLE_TIMES);
 
-                            // when trying to allocate a task but no task for more than `TASK_MAX_IDLE_TIMES`
+                            // when the planner trying to allocate a task but no task for more than `TASK_MAX_IDLE_TIMES`
                             // times, this task is really considered idle, break this task loop.
                             // that we have a chance to reload `sealing_thread` hot config file,
                             // or do something else.

--- a/venus-worker/src/sealing/worker/task/mod.rs
+++ b/venus-worker/src/sealing/worker/task/mod.rs
@@ -270,14 +270,14 @@ impl<'c> Task<'c> {
                 Ok(Some(evt)) => {
                     if let Event::Idle = evt {
                         task_idle_count += 1;
-                        if task_idle_count > self.store.config.allocate_max_retries {
+                        if task_idle_count > self.store.config.request_task_max_retries {
                             info!(
                                 "The task has returned `Event::Idle` for more than {} times. break the task",
-                                self.store.config.allocate_max_retries
+                                self.store.config.request_task_max_retries
                             );
 
-                            // when the planner tries to allocate a task but fails(including no task) for more than
-                            // `conig::sealing::allocate_max_retries` times, this task is really considered idle,
+                            // when the planner tries to request a task but fails(including no task) for more than
+                            // `conig::sealing::request_task_max_retries` times, this task is really considered idle,
                             // break this task loop. that we have a chance to reload `sealing_thread` hot config file,
                             // or do something else.
                             self.finalize()?;

--- a/venus-worker/src/sealing/worker/task/mod.rs
+++ b/venus-worker/src/sealing/worker/task/mod.rs
@@ -275,7 +275,7 @@ impl<'c> Task<'c> {
                         if task_idle_count > TASK_MAX_IDLE_TIMES {
                             info!("The task has been idle for more than {} times. break the task", TASK_MAX_IDLE_TIMES);
 
-                            // when trying to allocate a task but no task for more than `TASK_MAX_IDLE_TIMES` 
+                            // when trying to allocate a task but no task for more than `TASK_MAX_IDLE_TIMES`
                             // times, this task is really considered idle, break this task loop.
                             // that we have a chance to reload `sealing_thread` hot config file,
                             // or do something else.

--- a/venus-worker/src/sealing/worker/task/planner/sealer.rs
+++ b/venus-worker/src/sealing/worker/task/planner/sealer.rs
@@ -169,7 +169,7 @@ impl<'c, 't> Sealer<'c, 't> {
 
         let sector = match maybe_allocated {
             Some(a) => a,
-            None => return Ok(Event::Retry),
+            None => return Ok(Event::Idle),
         };
 
         // init required dirs & files

--- a/venus-worker/src/sealing/worker/task/planner/sealer.rs
+++ b/venus-worker/src/sealing/worker/task/planner/sealer.rs
@@ -163,7 +163,7 @@ impl<'c, 't> Sealer<'c, 't> {
             Ok(a) => a,
             Err(e) => {
                 warn!("sectors are not allocated yet, so we can retry even though we got the err {:?}", e);
-                return Ok(Event::Retry);
+                return Ok(Event::Idle);
             }
         };
 

--- a/venus-worker/src/sealing/worker/task/planner/snapup.rs
+++ b/venus-worker/src/sealing/worker/task/planner/snapup.rs
@@ -112,7 +112,7 @@ impl<'c, 't> SnapUp<'c, 't> {
             Ok(a) => a,
             Err(e) => {
                 warn!("sectors are not allocated yet, so we can retry even though we got the err {:?}", e);
-                return Ok(Event::Retry);
+                return Ok(Event::Idle);
             }
         };
 

--- a/venus-worker/src/sealing/worker/task/planner/snapup.rs
+++ b/venus-worker/src/sealing/worker/task/planner/snapup.rs
@@ -118,7 +118,7 @@ impl<'c, 't> SnapUp<'c, 't> {
 
         let allocated = match maybe_allocated {
             Some(a) => a,
-            None => return Ok(Event::Retry),
+            None => return Ok(Event::Idle),
         };
 
         if allocated.pieces.is_empty() {


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

related to #362

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->

venus-worker 新增 Event::Idle 类型， 当 Planner 获取任务返回 None 时返回 Event::Idle.
当 Planner Idle 超过阈值(目前是 3)后，退出循环，以便于有机会重新加载 sealing_thread 配置

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 具有清晰明确的 commit message / All commits have a clear commit message.
- [ ] 包含必要的测试用例 / This PR has tests for new functionality or change in behaviour
- [ ] 包含必要的指南或文档 / If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included
- [x] 通过必要的检查项 / All checks are green
