### PR TITLE
fix(worker): idle if no deals

### DIFF
--- a/venus-worker/src/sealing/worker/task/planner/sealer.rs
+++ b/venus-worker/src/sealing/worker/task/planner/sealer.rs
@@ -183,27 +183,25 @@ impl<'c, 't> Sealer<'c, 't> {
 
         let sector_id = self.task.sector_id()?.clone();
 
-        loop {
-            let deals = call_rpc! {
-                self.task.ctx.global.rpc,
-                acquire_deals,
-                sector_id.clone(),
-                AcquireDealsSpec {
-                    max_deals: self.task.store.config.max_deals,
-                    min_used_space: self.task.store.config.min_deal_space.map(|b| b.get_bytes() as usize),
-                },
-            }?;
+        let deals = call_rpc! {
+            self.task.ctx.global.rpc,
+            acquire_deals,
+            sector_id,
+            AcquireDealsSpec {
+                max_deals: self.task.store.config.max_deals,
+                min_used_space: self.task.store.config.min_deal_space.map(|b| b.get_bytes() as usize),
+            },
+        }?;
 
-            let deals_count = deals.as_ref().map(|d| d.len()).unwrap_or(0);
+        let deals_count = deals.as_ref().map(|d| d.len()).unwrap_or(0);
 
-            debug!(count = deals_count, "pieces acquired");
+        debug!(count = deals_count, "pieces acquired");
 
-            if !self.task.store.config.disable_cc || deals_count > 0 {
-                return Ok(Event::AcquireDeals(deals));
-            }
-
-            self.task.wait_or_interruptted(self.task.store.config.rpc_polling_interval)?;
-        }
+        Ok(if !self.task.store.config.disable_cc || deals_count > 0 {
+            Event::AcquireDeals(deals)
+        } else {
+            Event::Idle
+        })
     }
 
     fn handle_deals_acquired(&self) -> ExecResult {


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
#362 

当前 sealer planner 申请新扇区仅仅只需要满足扇区号规则等限制。因此无法按照预期进入 idle 状态。
考虑在申请 deals 时，若未获取到 deals 则进入 idle状态，使得有机会退出任务循环重新加载热配置文件。

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
当 sealer planer 获取不到 deals 时，进入 Idle 状态。


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->
1. cc 扇区任务会在封装完成后退出 task 从而有机会重新加载热配置文件
2. acquire_deals rpc 请求不重试多次，一旦没有deals 直接进入 Idle， 因为从语义上来说没有 deals 确实属于 idle， 并且 Task 循环在接收到 Event::Idle 事件时也会重试 `request_task_max_retries` 次

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合 Venus 项目管理规范中关于 PR 的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的 [commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
