### PR TITLE
Fix/0x5459/sealer reserve sector

### DIFF
--- a/venus-worker/src/metadb/mod.rs
+++ b/venus-worker/src/metadb/mod.rs
@@ -256,3 +256,35 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::MaybeDirty;
+
+    #[test]
+    fn test_maybe_dirty() {
+        let mut x = String::from("glgjssy");
+        let mut md = MaybeDirty::new(x.clone());
+        assert_eq!(x, *md);
+        assert!(!md.is_dirty());
+
+        md.push_str(", qyhfbqz. ");
+        assert_ne!(x, *md);
+        assert!(md.is_dirty());
+        x.push_str(", qyhfbqz. ");
+
+        md.sync();
+        assert!(!md.is_dirty());
+
+        md.push_str("sometimes");
+        assert!(md.is_dirty());
+        x.push_str("sometimes");
+
+        assert_eq!(x, *md);
+
+        // avoid panic
+        md.sync();
+    }
+}

--- a/venus-worker/src/metadb/mod.rs
+++ b/venus-worker/src/metadb/mod.rs
@@ -244,19 +244,6 @@ where
     }
 }
 
-impl<T, K, DB> Drop for Saved<T, K, DB>
-where
-    T: Default + Serialize,
-    K: AsRef<str>,
-    DB: MetaDB,
-{
-    fn drop(&mut self) {
-        if let Err(e) = self.sync() {
-            error!(err = ?e, "sync data");
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;

--- a/venus-worker/src/sealing/hot_config.rs
+++ b/venus-worker/src/sealing/hot_config.rs
@@ -1,6 +1,5 @@
 //! definition of the HotConfig
 
-use std::convert::identity;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
@@ -9,18 +8,13 @@ use std::time::SystemTime;
 use anyhow::Context;
 use serde::Deserialize;
 
-enum CheckModified {
-    Modified,
-    Deleted,
-    NotModified,
-}
-
 /// HotConfig can load configuration updates without restarts
 /// `T` is the type of the config we need.
 /// `U` is the type of the hot config file content.
 /// merge the `hot_config: U` to `default_config: T` by `merge_config_fn`
 pub struct HotConfig<T, U> {
     current_config: T,
+    new_config: Option<T>,
     default_config: T,
     merge_config_fn: fn(&T, U) -> T,
 
@@ -39,16 +33,17 @@ where
     pub fn new(default_config: T, merge_config_fn: fn(&T, U) -> T, path: impl Into<PathBuf>) -> anyhow::Result<Self> {
         let mut hot = Self {
             current_config: default_config.clone(),
+            new_config: None,
             default_config,
             merge_config_fn,
             path: path.into(),
             last_modified: None,
         };
-        hot.check_modified()?;
+        hot.if_modified(|_, _| Ok(true))?;
         Ok(hot)
     }
 
-    fn check_modified(&mut self) -> anyhow::Result<CheckModified> {
+    fn check_modified(&mut self) -> anyhow::Result<()> {
         match fs::metadata(&self.path).and_then(|m| m.modified()) {
             // Hot config file modified
             Ok(latest_modified) if self.last_modified.map(|m| latest_modified != m).unwrap_or(true) => {
@@ -56,13 +51,12 @@ where
 
                 let content = fs::read_to_string(&self.path).with_context(|| format!("read hot config: '{}'", self.path.display()))?;
                 let hot_config: U = toml::from_str(&content).context("deserializes toml file for hot config")?;
-                self.current_config = (self.merge_config_fn)(&self.default_config, hot_config);
-
-                Ok(CheckModified::Modified)
+                self.new_config = Some((self.merge_config_fn)(&self.default_config, hot_config));
+                Ok(())
             }
 
             // The current config is up to date
-            Ok(_) => Ok(CheckModified::NotModified),
+            Ok(_) => Ok(()),
 
             // The hot config file does not exist
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
@@ -70,11 +64,9 @@ where
                 // that means the hot config file is deleted.
                 // since self.last_modified is assigned to some only if the hot config file exists
                 if self.last_modified.take().is_some() {
-                    self.current_config = self.default_config.clone();
-                    Ok(CheckModified::Deleted)
-                } else {
-                    Ok(CheckModified::NotModified)
+                    self.new_config = Some(self.default_config.clone());
                 }
+                Ok(())
             }
 
             Err(e) => Err(anyhow::anyhow!("check modified for hot config. err: {:?}", e)),
@@ -82,22 +74,26 @@ where
     }
 
     /// Call the given function `f` if the content of the hot config file is modified
-    /// or the hot config file deleted compared to the last check
-    pub fn if_modified<E>(&mut self, f: impl FnOnce(&T) -> Result<(), E>) -> anyhow::Result<Result<(), E>> {
-        Ok(match self.check_modified()? {
-            CheckModified::Modified | CheckModified::Deleted => f(self.config()),
-            CheckModified::NotModified => Ok(()),
-        })
+    /// or the hot config file deleted compared to the last check.
+    ///
+    /// Apply the new config if the `f` function returns true.
+    pub fn if_modified(&mut self, f: impl FnOnce(&T, &T) -> anyhow::Result<bool>) -> anyhow::Result<bool> {
+        self.check_modified()?;
+
+        let replace = match &self.new_config {
+            Some(new_config) => f(&self.current_config, new_config)?,
+            None => false,
+        };
+        if replace {
+            self.current_config = self.new_config.take().unwrap();
+        }
+        Ok(replace)
     }
 
     /// Returns current config
     pub fn config(&self) -> &T {
         &self.current_config
     }
-}
-
-pub(crate) fn result_flatten<T, E>(x: Result<Result<T, E>, E>) -> Result<T, E> {
-    x.and_then(identity)
 }
 
 #[cfg(test)]
@@ -140,13 +136,8 @@ mod tests {
 
     macro_rules! expect_config {
         ($hot:expr, $expect:expr) => {
-            let mut actual_config = None;
-            let _ = $hot
-                .if_modified(|c| {
-                    actual_config = Some(c.clone());
-                    Ok::<_, ()>(())
-                })
-                .expect("failed to check hot config file");
+            let modified = $hot.if_modified(|_, _| Ok(true)).expect("failed to check hot config file");
+            let actual_config = if modified { Some($hot.config()) } else { None };
             assert_eq!($expect, actual_config);
         };
     }
@@ -165,17 +156,17 @@ mod tests {
 
         sleep_1s();
         write_toml_file(&hot_config_path, &config!(v2));
-        expect_config!(&mut hot, Some(merge_config(&default_config, config!(v2))));
+        expect_config!(&mut hot, Some(&merge_config(&default_config, config!(v2))));
         // The config should not change without modifying the hot config file
         expect_config!(&mut hot, None);
 
         fs::remove_file(&hot_config_path).expect("failed to remove hot config file");
-        expect_config!(&mut hot, Some(default_config.clone()));
+        expect_config!(&mut hot, Some(&default_config));
         expect_config!(&mut hot, None);
 
         sleep_1s();
         write_toml_file(&hot_config_path, &config!(v3));
-        expect_config!(&mut hot, Some(merge_config(&default_config, config!(v3))));
+        expect_config!(&mut hot, Some(&merge_config(&default_config, config!(v3))));
         // The config should not change without modifying the hot config file
         expect_config!(&mut hot, None);
     }
@@ -187,6 +178,19 @@ mod tests {
             HotConfig::new(default_config.clone(), merge_config, PathBuf::from("/non_exist_file")).expect("Failed to new HotConfig");
         assert_eq!(&default_config, hot.config());
         expect_config!(&mut hot, None);
+    }
+
+    #[test]
+    fn test_if_modified_when_given_false() {
+        let tempdir = tempfile::tempdir().expect("failed to create temp dir");
+        let default_config = config!(v0);
+        let hot_config_path = tempdir.path().join("hot.toml");
+        let mut hot = HotConfig::new(default_config.clone(), merge_config, &hot_config_path).expect("failed to new HotConfig");
+        
+        sleep_1s();
+        write_toml_file(&hot_config_path, &config!(v1));
+        hot.if_modified(|_, _| Ok(false)).unwrap();
+        assert_eq!(&default_config, hot.config());
     }
 
     fn write_toml_file(path: impl AsRef<Path>, config: &Config) {

--- a/venus-worker/src/sealing/hot_config.rs
+++ b/venus-worker/src/sealing/hot_config.rs
@@ -5,8 +5,16 @@ use std::io;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 use serde::Deserialize;
+use tracing::error;
+
+enum ConfigEvent {
+    Unchanged,
+    Created(SystemTime),
+    Deleted,
+    Modified(SystemTime),
+}
 
 /// HotConfig can load configuration updates without restarts
 /// `T` is the type of the config we need.
@@ -43,56 +51,89 @@ where
         Ok(hot)
     }
 
-    fn check_modified(&mut self) -> anyhow::Result<()> {
-        match fs::metadata(&self.path).and_then(|m| m.modified()) {
-            // Hot config file modified
-            Ok(latest_modified) if self.last_modified.map(|m| latest_modified != m).unwrap_or(true) => {
-                self.last_modified = Some(latest_modified);
-
-                let content = fs::read_to_string(&self.path).with_context(|| format!("read hot config: '{}'", self.path.display()))?;
-                let hot_config: U = toml::from_str(&content).context("deserializes toml file for hot config")?;
-                self.new_config = Some((self.merge_config_fn)(&self.default_config, hot_config));
-                Ok(())
-            }
-
-            // The current config is up to date
-            Ok(_) => Ok(()),
-
-            // The hot config file does not exist
-            Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                // If the hot config file does not exist, but the self.last_modified is some,
-                // that means the hot config file is deleted.
-                // since self.last_modified is assigned to some only if the hot config file exists
-                if self.last_modified.take().is_some() {
-                    self.new_config = Some(self.default_config.clone());
-                }
-                Ok(())
-            }
-
-            Err(e) => Err(anyhow::anyhow!("check modified for hot config. err: {:?}", e)),
-        }
-    }
-
     /// Call the given function `f` if the content of the hot config file is modified
     /// or the hot config file deleted compared to the last check.
     ///
     /// Apply the new config if the `f` function returns true.
     pub fn if_modified(&mut self, f: impl FnOnce(&T, &T) -> anyhow::Result<bool>) -> anyhow::Result<bool> {
-        self.check_modified()?;
+        self.try_load()?;
 
-        let replace = match &self.new_config {
+        let should_apply = match &self.new_config {
             Some(new_config) => f(&self.current_config, new_config)?,
             None => false,
         };
-        if replace {
+        if should_apply {
             self.current_config = self.new_config.take().unwrap();
         }
-        Ok(replace)
+        Ok(should_apply)
+    }
+
+    // Returns `true` if the hot config modified.
+    pub fn check_modified(&self) -> bool {
+        match self.check_modified_inner().unwrap_or_else(|e| {
+            error!(err=?e, "check modified error");
+
+            // if `check_modified_inner` reports an error, the configuration is considered unchanged.
+            ConfigEvent::Unchanged
+        }) {
+            ConfigEvent::Unchanged => false,
+            _ => true,
+        }
     }
 
     /// Returns current config
     pub fn config(&self) -> &T {
         &self.current_config
+    }
+
+    fn check_modified_inner(&self) -> anyhow::Result<ConfigEvent> {
+        Ok(match (fs::metadata(&self.path).and_then(|m| m.modified()), self.last_modified) {
+            (Ok(latest_modified), Some(last_modified)) => {
+                if latest_modified != last_modified {
+                    // hot config file modified
+                    ConfigEvent::Modified(latest_modified)
+                } else {
+                    ConfigEvent::Unchanged
+                }
+            }
+
+            // hot config file created
+            (Ok(latest_modified), None) => ConfigEvent::Created(latest_modified),
+
+            (Err(e), last_modified_opt) => {
+                if e.kind() == io::ErrorKind::NotFound {
+                    match last_modified_opt {
+                        // If the hot config file does not exist, but the self.last_modified is some,
+                        // that means the hot config file is deleted.
+                        Some(_) => ConfigEvent::Deleted,
+                        None => ConfigEvent::Unchanged,
+                    }
+                } else {
+                    bail!("check modified for hot config. err: {:?}", e)
+                }
+            }
+        })
+    }
+
+    fn try_load(&mut self) -> anyhow::Result<()> {
+        match self.check_modified_inner()? {
+            ConfigEvent::Created(latest_modified) | ConfigEvent::Modified(latest_modified) => {
+                self.last_modified = Some(latest_modified);
+
+                let content = fs::read_to_string(&self.path).with_context(|| format!("read hot config: '{}'", self.path.display()))?;
+                let hot_config: U = toml::from_str(&content).context("deserializes toml file for hot config")?;
+                self.new_config = Some((self.merge_config_fn)(&self.default_config, hot_config));
+            }
+            ConfigEvent::Deleted => {
+                if self.last_modified.take().is_some() {
+                    self.new_config = Some(self.default_config.clone());
+                }
+            }
+            ConfigEvent::Unchanged => {
+                // do nothing
+            }
+        }
+        Ok(())
     }
 }
 
@@ -186,11 +227,37 @@ mod tests {
         let default_config = config!(v0);
         let hot_config_path = tempdir.path().join("hot.toml");
         let mut hot = HotConfig::new(default_config.clone(), merge_config, &hot_config_path).expect("failed to new HotConfig");
-        
+
         sleep_1s();
         write_toml_file(&hot_config_path, &config!(v1));
         hot.if_modified(|_, _| Ok(false)).unwrap();
         assert_eq!(&default_config, hot.config());
+    }
+
+    #[test]
+    fn test_check_modified() {
+        let tempdir = tempfile::tempdir().expect("failed to create temp dir");
+        let default_config = config!(v0);
+        let hot_config_path = tempdir.path().join("hot.toml");
+        let mut hot = HotConfig::new(default_config.clone(), merge_config, &hot_config_path).expect("failed to new HotConfig");
+        assert!(!hot.check_modified());
+        write_toml_file(&hot_config_path, &config!(v1));
+        assert!(hot.check_modified());
+        assert!(hot.check_modified());
+        hot.if_modified(|_, _| Ok(true)).unwrap();
+        assert!(!hot.check_modified());
+
+        fs::remove_file(&hot_config_path).expect("failed to remove hot config file");
+        assert!(hot.check_modified());
+        assert!(hot.check_modified());
+        hot.if_modified(|_, _| Ok(true)).unwrap();
+        assert!(!hot.check_modified());
+
+        write_toml_file(&hot_config_path, &config!(v1));
+        assert!(hot.check_modified());
+        assert!(hot.check_modified());
+        hot.if_modified(|_, _| Ok(true)).unwrap();
+        assert!(!hot.check_modified());
     }
 
     fn write_toml_file(path: impl AsRef<Path>, config: &Config) {

--- a/venus-worker/src/sealing/store/mod.rs
+++ b/venus-worker/src/sealing/store/mod.rs
@@ -182,6 +182,11 @@ impl Config {
         Ok(())
     }
 
+    /// Returns `true` if the hot config modified.
+    pub fn check_modified(&self) -> bool {
+        self.hot_config.check_modified()
+    }
+
     /// Returns the plan config item
     pub fn plan(&self) -> &Option<String> {
         &self.hot_config.config().plan

--- a/venus-worker/src/sealing/store/mod.rs
+++ b/venus-worker/src/sealing/store/mod.rs
@@ -170,9 +170,7 @@ impl Config {
 
     /// Reload hot config when the content of hot config modified
     pub fn reload_if_needed(&mut self, f: impl FnOnce(&SealingWithPlan, &SealingWithPlan) -> Result<bool>) -> Result<()> {
-        let modified = self.hot_config.if_modified(f)?;
-
-        if modified {
+        if self.hot_config.if_modified(f)? {
             let config = self.hot_config.config();
             info!(config = ?config, "sealing thread reload hot config");
 

--- a/venus-worker/src/sealing/store/mod.rs
+++ b/venus-worker/src/sealing/store/mod.rs
@@ -14,7 +14,7 @@ use crate::infra::util::PlaceHolder;
 use crate::logging::{info, warn};
 use crate::metadb::rocks::RocksMeta;
 use crate::sealing::{
-    hot_config::{result_flatten, HotConfig},
+    hot_config::HotConfig,
     worker::{Ctrl, Worker},
 };
 use crate::types::SealProof;
@@ -169,12 +169,17 @@ impl Config {
     }
 
     /// Reload hot config when the content of hot config modified
-    pub fn reload_if_needed(&mut self) -> Result<()> {
-        result_flatten(self.hot_config.if_modified(|config| {
-            (self.allowed_miners, self.allowed_proof_types) = Self::extract_allowed(&config.sealing)?;
+    pub fn reload_if_needed(&mut self, f: impl FnOnce(&SealingWithPlan, &SealingWithPlan) -> Result<bool>) -> Result<()> {
+        let modified = self.hot_config.if_modified(f)?;
+
+        if modified {
+            let config = self.hot_config.config();
             info!(config = ?config, "sealing thread reload hot config");
-            Ok(())
-        }))
+
+            (self.allowed_miners, self.allowed_proof_types) = Self::extract_allowed(&config.sealing)?;
+        }
+
+        Ok(())
     }
 
     /// Returns the plan config item
@@ -256,10 +261,13 @@ fn customized_sealing_config(common: &SealingOptional, customized: Option<&Seali
     }
 }
 
+/// sealing config with plan
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct SealingWithPlan {
-    plan: Option<String>,
-    sealing: Sealing,
+pub struct SealingWithPlan {
+    /// sealing plan
+    pub plan: Option<String>,
+    /// sealing config
+    pub sealing: Sealing,
 }
 
 /// Merge hot config and default config

--- a/venus-worker/src/sealing/worker/task/event.rs
+++ b/venus-worker/src/sealing/worker/task/event.rs
@@ -6,12 +6,12 @@ use super::{
     sector::{Base, Finalized, Sector, State},
     Planner,
 };
-use crate::logging::trace;
 use crate::rpc::sealer::{AllocatedSector, Deals, SectorRebuildInfo, Seed, Ticket};
 use crate::sealing::processor::{
     to_prover_id, PieceInfo, SealCommitPhase1Output, SealCommitPhase2Output, SealPreCommitPhase1Output, SealPreCommitPhase2Output,
     SectorId, SnapEncodeOutput,
 };
+use crate::{logging::trace, metadb::MaybeDirty};
 
 pub enum Event {
     SetState(State),
@@ -158,7 +158,7 @@ macro_rules! mem_replace {
 }
 
 impl Event {
-    pub fn apply<P: Planner>(self, p: &P, s: &mut Sector) -> Result<()> {
+    pub fn apply<P: Planner>(self, p: &P, s: &mut MaybeDirty<Sector>) -> Result<()> {
         let next = if let Event::SetState(s) = self {
             s
         } else {
@@ -175,7 +175,7 @@ impl Event {
         Ok(())
     }
 
-    fn apply_changes(self, s: &mut Sector) {
+    fn apply_changes(self, s: &mut MaybeDirty<Sector>) {
         match self {
             Self::SetState(_) => {}
 

--- a/venus-worker/src/sealing/worker/task/mod.rs
+++ b/venus-worker/src/sealing/worker/task/mod.rs
@@ -8,7 +8,7 @@ use self::planner::default_plan;
 
 use super::{super::failure::*, CtrlCtx};
 use crate::logging::{debug, error, info, warn, warn_span};
-use crate::metadb::{rocks::RocksMeta, MetaDocumentDB, MetaError, PrefixedMetaDB};
+use crate::metadb::{rocks::RocksMeta, MaybeDirty, MetaDocumentDB, PrefixedMetaDB, Saved};
 use crate::rpc::sealer::{ReportStateReq, SectorFailure, SectorID, SectorStateChange, WorkerIdentifier};
 use crate::store::Store;
 use crate::types::SealProof;
@@ -35,7 +35,7 @@ const SECTOR_META_PREFIX: &str = "meta";
 const SECTOR_TRACE_PREFIX: &str = "trace";
 
 pub struct Task<'c> {
-    sector: Sector,
+    sector: Saved<Sector, &'static str, PrefixedMetaDB<&'c RocksMeta>>,
     _trace: Vec<Trace>,
 
     ctx: &'c Ctx,
@@ -43,8 +43,7 @@ pub struct Task<'c> {
     store: &'c Store,
     ident: WorkerIdentifier,
 
-    sector_meta: MetaDocumentDB<PrefixedMetaDB<'c, RocksMeta>>,
-    _trace_meta: MetaDocumentDB<PrefixedMetaDB<'c, RocksMeta>>,
+    _trace_meta: MetaDocumentDB<PrefixedMetaDB<&'c RocksMeta>>,
 }
 
 // properties
@@ -77,25 +76,24 @@ impl<'c> Task<'c> {
             ..
         } = s;
 
-        let sector_meta = MetaDocumentDB::wrap(PrefixedMetaDB::wrap(SECTOR_META_PREFIX, &*store_meta));
+        let sector_meta = PrefixedMetaDB::wrap(SECTOR_META_PREFIX, &*store_meta);
+        let mut sector: Saved<Sector, _, _> = Saved::load(SECTOR_INFO_KEY, sector_meta).context("load sector").crit()?;
 
-        let sector: Sector = sector_meta
-            .get(SECTOR_INFO_KEY)
-            .or_else(|e| match e {
-                MetaError::NotFound => {
-                    // meta data not found means that we are dealing with a new sector.
-                    // in this case we can load the sealing_thread hot config without any side effects.
-                    store_config.reload_if_needed().context("reload sealing thread hot config")?;
-
-                    let _ = get_planner(store_config.plan().as_deref())?;
-                    let empty = Sector::new(store_config.plan().as_ref().cloned());
-                    sector_meta.set(SECTOR_INFO_KEY, &empty)?;
-                    Ok(empty)
+        store_config
+            .reload_if_needed(|old_config, new_config| {
+                let need_cleanup_sector = sector.state == State::Allocated
+                    && (old_config.sealing.allowed_sizes != new_config.sealing.allowed_sizes
+                        || old_config.sealing.allowed_miners != new_config.sealing.allowed_miners);
+                if need_cleanup_sector {
+                    sector.delete().context("cleanup sector")?;
                 }
-
-                MetaError::Failure(ie) => Err(ie),
+                if sector.plan != new_config.plan {
+                    sector.plan = new_config.plan.clone();
+                }
+                sector.sync().context("init sync sector")?;
+                Ok(sector.can_be_reload_config())
             })
-            .context("load or create sector")
+            .context("reload sealing thread hot config")
             .crit()?;
 
         ctrl_ctx
@@ -117,7 +115,6 @@ impl<'c> Task<'c> {
                 location: s.location.to_pathbuf(),
             },
 
-            sector_meta,
             _trace_meta: trace_meta,
         })
     }
@@ -288,7 +285,6 @@ impl<'c> Task<'c> {
                             // `conig::sealing::request_task_max_retries` times, this task is really considered idle,
                             // break this task loop. that we have a chance to reload `sealing_thread` hot config file,
                             // or do something else.
-                            self.finalize()?;
                             return Ok(());
                         }
                     }
@@ -348,15 +344,14 @@ impl<'c> Task<'c> {
         }
     }
 
-    fn sync<F: FnOnce(&mut Sector) -> Result<()>>(&mut self, modify_fn: F) -> Result<(), Failure> {
-        modify_fn(&mut self.sector).crit()?;
-        self.sector_meta.set(SECTOR_INFO_KEY, &self.sector).crit()
+    fn sync<F: FnOnce(&mut MaybeDirty<Sector>) -> Result<()>>(&mut self, modify_fn: F) -> Result<(), Failure> {
+        modify_fn(self.sector.inner_mut()).crit()?;
+        self.sector.sync().context("sync sector").crit()
     }
 
-    fn finalize(self) -> Result<(), Failure> {
-        self.store.cleanup().crit()?;
-        self.sector_meta.remove(SECTOR_INFO_KEY).crit()?;
-        Ok(())
+    fn finalize(mut self) -> Result<(), Failure> {
+        self.store.cleanup().context("cleanup store").crit()?;
+        self.sector.delete().context("remove sector").crit()
     }
 
     fn sector_path(&self, sector_id: &SectorID) -> String {

--- a/venus-worker/src/sealing/worker/task/mod.rs
+++ b/venus-worker/src/sealing/worker/task/mod.rs
@@ -80,13 +80,12 @@ impl<'c> Task<'c> {
         let mut sector: Saved<Sector, _, _> = Saved::load(SECTOR_INFO_KEY, sector_meta).context("load sector").crit()?;
 
         store_config
-            .reload_if_needed(|_, _| Ok(true))
+            .reload_if_needed(|_, new_config| {
+                sector.plan = new_config.plan.clone();
+                Ok(true)
+            })
             .context("reload sealing thread hot config")
             .crit()?;
-
-        if &sector.plan != store_config.plan() {
-            sector.plan = store_config.plan().clone();
-        }
 
         // create sector or sync sector plan
         sector.sync().context("init sync sector").crit()?;

--- a/venus-worker/src/sealing/worker/task/sector.rs
+++ b/venus-worker/src/sealing/worker/task/sector.rs
@@ -191,11 +191,4 @@ impl Sector {
         let prev = std::mem::replace(&mut self.state, next);
         self.prev_state.replace(prev);
     }
-
-    pub fn can_be_reload_config(&self) -> bool {
-        match self.state {
-            State::Empty | State::Allocated => true,
-            _ => false,
-        }
-    }
 }

--- a/venus-worker/src/sealing/worker/task/sector.rs
+++ b/venus-worker/src/sealing/worker/task/sector.rs
@@ -163,28 +163,39 @@ pub struct Sector {
     pub phases: Phases,
 }
 
-impl Sector {
-    pub fn new(plan: Option<String>) -> Self {
-        Sector {
+impl Default for Sector {
+    fn default() -> Self {
+        Self {
             version: CURRENT_SECTOR_VERSION,
-            plan,
-
+            plan: None,
             state: Default::default(),
             prev_state: None,
             retry: 0,
-
             base: None,
-
             deals: None,
-
             finalized: None,
-
             phases: Default::default(),
         }
+    }
+}
+
+impl Sector {
+    #[allow(dead_code)]
+    pub fn new(plan: Option<String>) -> Self {
+        let mut s = Sector::default();
+        s.plan = plan;
+        s
     }
 
     pub fn update_state(&mut self, next: State) {
         let prev = std::mem::replace(&mut self.state, next);
         self.prev_state.replace(prev);
+    }
+
+    pub fn can_be_reload_config(&self) -> bool {
+        match self.state {
+            State::Empty | State::Allocated => true,
+            _ => false,
+        }
     }
 }


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
#362

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
1. sealer planner 在 Allocated 状态且获取不到 deals 时会返回 Event::idle, 超过 `request_task_max_retries` 次后会清除扇区数据重新开始任务循环，这样会浪费 `allocate_sector` 时申请的扇区号, 现在不会在 Event::idle 超过 `request_task_max_retries` 次后清除扇区数据，该部分逻辑移动到 `Task::build` 中。
2. 新增 MaybeDirty 避免不必要的写数据库操作

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合 Venus 项目管理规范中关于 PR 的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的 [commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
