### PR TITLE
fix(worker): downgrade the version of time crate to fix `unknown time` bug

### DIFF
--- a/venus-worker/Cargo.lock
+++ b/venus-worker/Cargo.lock
@@ -3857,31 +3857,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.19"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
-name = "time-macros"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
-dependencies = [
- "time-core",
 ]
 
 [[package]]
@@ -4085,7 +4067,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.19",
+ "time 0.3.9",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/venus-worker/Makefile
+++ b/venus-worker/Makefile
@@ -16,6 +16,13 @@ all: fmt clippy build-all
 
 check-all: check-fmt check-clippy
 
+# Add `--cfg unsound_local_offset` flag to allow time crate to get the local time zone. \
+See: https://docs.rs/time/0.3.9/time/index.html#feature-flags and \
+https://github.com/time-rs/time/issues/293#issuecomment-1005002386
+ifeq ($(findstring --cfg unsound_local_offset, $(RUSTFLAGS)), )
+RUSTFLAGS+=--cfg unsound_local_offset
+endif
+
 build-all:
 	cargo build --release --workspace $(VENUS_WORKER_FEATURE_FLAGS)
 

--- a/venus-worker/src/config.rs
+++ b/venus-worker/src/config.rs
@@ -355,6 +355,10 @@ impl Config {
 
     /// render the config content
     pub fn render(&self) -> Result<String> {
-        toml::to_string_pretty(self).context("serialize config to toml")
+        use std::io::Write;
+
+        let mut buf = Vec::new();
+        writeln!(&mut buf, "{:#?}", self)?;
+        Ok(String::from_utf8(buf)?)
     }
 }


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->


## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
* 降级 time crate 版本，修复 tracing-subscriber 日志的 `<unknown time>` bug

* toml 在配置文件输出时不支持 u128, 所以配置文件格式化打印从 toml 格式改为 rust 自带的格式化输出

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合 Venus 项目管理规范中关于 PR 的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的 [commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
